### PR TITLE
chain dump scripts make binary independent chain-specs

### DIFF
--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -29,9 +29,5 @@ mkdir -p $DUMP_DIR
 $COLLATOR --version
 # Print array values in  lines
 for spec in ${chainspecs[*]}; do
-  echo "dumping spec for $spec"
-  $COLLATOR build-spec --chain $spec >  $DUMP_DIR/${spec}.json
-  $COLLATOR build-spec --chain $spec --raw > $DUMP_DIR/${spec}-raw.json
-  $COLLATOR export-genesis-state --chain $DUMP_DIR/${spec}-raw.json --parachain-id 2015 > $DUMP_DIR/${spec}.state
-  $COLLATOR export-genesis-wasm --chain $DUMP_DIR/${spec}-raw.json >  $DUMP_DIR/${spec}.wasm
+  ./scripts/dump_wasm_state_and_spec.sh ${spec}
 done

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -5,7 +5,7 @@
 #
 # Usage: ./scripts/dump_wasm_and_state_for_all_chains.sh <para-id> <collator-binary> <dump-dir>
 #
-# Example: ./scripts/dump_wasm_state_and_spec.sh 2000 ./
+# Example: ./scripts/dump_wasm_state_and_spec.sh 2000 ./collator ./dump_dir
 #
 # All arguments are optional.
 

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -30,8 +30,8 @@ $COLLATOR --version
 # Print array values in  lines
 for spec in ${chainspecs[*]}; do
   echo "dumping spec for $spec"
-  $COLLATOR export-genesis-state --chain $spec --parachain-id 2015 > $DUMP_DIR/${spec}.state
-  $COLLATOR export-genesis-wasm --chain $spec >  $DUMP_DIR/${spec}.wasm
   $COLLATOR build-spec --chain $spec >  $DUMP_DIR/${spec}.json
   $COLLATOR build-spec --chain $spec --raw > $DUMP_DIR/${spec}-raw.json
+  $COLLATOR export-genesis-state --chain $DUMP_DIR/${spec}-raw.json --parachain-id 2015 > $DUMP_DIR/${spec}.state
+  $COLLATOR export-genesis-wasm --chain $DUMP_DIR/${spec}-raw.json >  $DUMP_DIR/${spec}.wasm
 done

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -21,7 +21,7 @@ chainspecs=("integritee-rococo-local" \
 
       )
 
-COLLATOR=./target/release/integritee-collator
+COLLATOR=${1:-./target/release/integritee-collator}
 DUMP_DIR=./chain_dumps
 
 mkdir -p $DUMP_DIR
@@ -29,5 +29,5 @@ mkdir -p $DUMP_DIR
 $COLLATOR --version
 # Print array values in  lines
 for spec in ${chainspecs[*]}; do
-  ./scripts/dump_wasm_state_and_spec.sh ${spec}
+  ./scripts/dump_wasm_state_and_spec.sh ${spec} ${COLLATOR}
 done

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 # Remark: wasm and state will be identical for different relay-chains
+
+# Helper script to generate the wasm, state and chain-spec/ -raw.json for a all chain-specs.
+#
+# Usage: ./scripts/dump_wasm_and_state_for_all_chains.sh <para-id> <collator-binary>
+#
+# Example: ./scripts/dump_wasm_state_and_spec.sh 2000
+#
+# para-id, and collator-binary is optional
+
+PARA_ID=${1:-2015}
+COLLATOR=${2:-./target/release/integritee-collator}
+DUMP_DIR=./chain_dumps
+
+mkdir -p $DUMP_DIR
+
 chainspecs=("integritee-rococo-local" \
       "integritee-rococo-local-dev" \
       "integritee-rococo" \
@@ -20,12 +35,6 @@ chainspecs=("integritee-rococo-local" \
       "shell-polkadot" \
 
       )
-
-PARA_ID=${1:-2015}
-COLLATOR=${2:-./target/release/integritee-collator}
-DUMP_DIR=./chain_dumps
-
-mkdir -p $DUMP_DIR
 
 $COLLATOR --version
 # Print array values in  lines

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -3,17 +3,17 @@
 
 # Helper script to generate the wasm, state and chain-spec/ -raw.json for a all chain-specs.
 #
-# Usage: ./scripts/dump_wasm_and_state_for_all_chains.sh <para-id> <collator-binary>
+# Usage: ./scripts/dump_wasm_and_state_for_all_chains.sh <para-id> <collator-binary> <dump-dir>
 #
-# Example: ./scripts/dump_wasm_state_and_spec.sh 2000
+# Example: ./scripts/dump_wasm_state_and_spec.sh 2000 ./
 #
 # para-id, and collator-binary is optional
 
 PARA_ID=${1:-2015}
 COLLATOR=${2:-./target/release/integritee-collator}
-DUMP_DIR=./chain_dumps
+DUMP_DIR=${3-./chain_dumps}
 
-mkdir -p $DUMP_DIR
+mkdir -p ${DUMP_DIR}
 
 chainspecs=("integritee-rococo-local" \
       "integritee-rococo-local-dev" \
@@ -39,5 +39,5 @@ chainspecs=("integritee-rococo-local" \
 $COLLATOR --version
 # Print array values in  lines
 for spec in ${chainspecs[*]}; do
-  ./scripts/dump_wasm_state_and_spec.sh ${spec} ${PARA_ID} ${COLLATOR}
+  ./scripts/dump_wasm_state_and_spec.sh ${spec} ${PARA_ID} ${COLLATOR} ${DUMP_DIR}
 done

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -7,11 +7,11 @@
 #
 # Example: ./scripts/dump_wasm_state_and_spec.sh 2000 ./
 #
-# para-id, and collator-binary is optional
+# All arguments are optional.
 
 PARA_ID=${1:-2015}
 COLLATOR=${2:-./target/release/integritee-collator}
-DUMP_DIR=${3-./chain_dumps}
+DUMP_DIR=${3:-./chain_dumps}
 
 mkdir -p ${DUMP_DIR}
 

--- a/scripts/dump_wasm_and_state_for_all_chains.sh
+++ b/scripts/dump_wasm_and_state_for_all_chains.sh
@@ -21,7 +21,8 @@ chainspecs=("integritee-rococo-local" \
 
       )
 
-COLLATOR=${1:-./target/release/integritee-collator}
+PARA_ID=${1:-2015}
+COLLATOR=${2:-./target/release/integritee-collator}
 DUMP_DIR=./chain_dumps
 
 mkdir -p $DUMP_DIR
@@ -29,5 +30,5 @@ mkdir -p $DUMP_DIR
 $COLLATOR --version
 # Print array values in  lines
 for spec in ${chainspecs[*]}; do
-  ./scripts/dump_wasm_state_and_spec.sh ${spec} ${COLLATOR}
+  ./scripts/dump_wasm_state_and_spec.sh ${spec} ${PARA_ID} ${COLLATOR}
 done

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -4,7 +4,7 @@
 #
 # Usage: ./scripts/dump_wasm_state_and_spec.sh <chain-spec> <para-id> <collator-binary> <dump-dir>
 #
-# Example: ./scripts/dump_wasm_state_and_spec.sh shell-kusama-local-dev 2000
+# Example: ./scripts/dump_wasm_state_and_spec.sh shell-kusama-local-dev 2000 collator ./dump_dir
 #
 # chain-spec is mandatory, the rest is optional.
 

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -12,7 +12,7 @@
 CHAIN_SPEC=$1
 PARA_ID=${2:-2015}
 COLLATOR=${3:-./target/release/integritee-collator}
-DUMP_DIR=${4-./chain_dumps}
+DUMP_DIR=${4:-./chain_dumps}
 
 mkdir -p ${DUMP_DIR}
 

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -2,7 +2,7 @@
 
 # Helper script to generate the wasm, state and chain-spec/ -raw.json for a given chain-spec.
 #
-# Usage: ./scripts/dump_wasm_state_and_spec.sh <chain-spec> <para-id> <collator-binary>
+# Usage: ./scripts/dump_wasm_state_and_spec.sh <chain-spec> <para-id> <collator-binary> <dump-dir>
 #
 # Example: ./scripts/dump_wasm_state_and_spec.sh shell-kusama-local-dev 2000
 #
@@ -12,11 +12,14 @@
 CHAIN_SPEC=$1
 PARA_ID=${2:-2015}
 COLLATOR=${3:-./target/release/integritee-collator}
-DUMP_DIR=./chain_dumps
+DUMP_DIR=${4-./chain_dumps}
+
+mkdir -p ${DUMP_DIR}
 
 echo "dumping spec for: $CHAIN_SPEC"
 echo "para_id:          ${PARA_ID}"
 echo "collator:         ${COLLATOR}"
+echo "dump_dir:         ${DUMP_DIR}"
 echo ""
 
 $COLLATOR build-spec --chain ${CHAIN_SPEC} >$DUMP_DIR/${CHAIN_SPEC}.json

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# Remark: wasm and state will be identical for different relay-chains
+
+# Helper script to generate the wasm, state and chain-spec/ -raw.json for a given chain-spec.
+#
+# Usage: ./scripts/dump_wasm_state_and_spec.sh <chain-spec> <para-id> <collator-binary>
+#
+# Example: ./scripts/dump_wasm_state_and_spec.sh shell-kusama-local-dev 2000
+#
+# chain-spec is mandatory, the rest is optional.
+
 
 CHAIN_SPEC=$1
 PARA_ID=${2:-2015}
@@ -13,6 +21,8 @@ echo ""
 
 $COLLATOR build-spec --chain ${CHAIN_SPEC} >$DUMP_DIR/${CHAIN_SPEC}.json
 $COLLATOR build-spec --chain ${CHAIN_SPEC} --raw >$DUMP_DIR/${CHAIN_SPEC}-raw.json
+
+# Overwrite the rust-default value with the $PARA_ID
 sed -i "/\"para_id\": 2015/s/2015/${PARA_ID}/" $DUMP_DIR/${CHAIN_SPEC}.json
 sed -i "/\"para_id\": 2015/s/2015/${PARA_ID}/" $DUMP_DIR/${CHAIN_SPEC}-raw.json
 

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -3,7 +3,7 @@
 
 spec=$1
 
-COLLATOR=./target/release/integritee-collator
+COLLATOR=${2:-./target/release/integritee-collator}
 DUMP_DIR=./chain_dumps
 
 echo "dumping spec for $spec"

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Remark: wasm and state will be identical for different relay-chains
+
+spec=$1
+
+COLLATOR=./target/release/integritee-collator
+DUMP_DIR=./chain_dumps
+
+echo "dumping spec for $spec"
+$COLLATOR build-spec --chain $spec >  $DUMP_DIR/${spec}.json
+$COLLATOR build-spec --chain $spec --raw > $DUMP_DIR/${spec}-raw.json
+$COLLATOR export-genesis-state --chain $DUMP_DIR/${spec}-raw.json --parachain-id 2015 > $DUMP_DIR/${spec}.state
+$COLLATOR export-genesis-wasm --chain $DUMP_DIR/${spec}-raw.json >  $DUMP_DIR/${spec}.wasm

--- a/scripts/dump_wasm_state_and_spec.sh
+++ b/scripts/dump_wasm_state_and_spec.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 # Remark: wasm and state will be identical for different relay-chains
 
-spec=$1
-
-COLLATOR=${2:-./target/release/integritee-collator}
+CHAIN_SPEC=$1
+PARA_ID=${2:-2015}
+COLLATOR=${3:-./target/release/integritee-collator}
 DUMP_DIR=./chain_dumps
 
-echo "dumping spec for $spec"
-$COLLATOR build-spec --chain $spec >  $DUMP_DIR/${spec}.json
-$COLLATOR build-spec --chain $spec --raw > $DUMP_DIR/${spec}-raw.json
-$COLLATOR export-genesis-state --chain $DUMP_DIR/${spec}-raw.json --parachain-id 2015 > $DUMP_DIR/${spec}.state
-$COLLATOR export-genesis-wasm --chain $DUMP_DIR/${spec}-raw.json >  $DUMP_DIR/${spec}.wasm
+echo "dumping spec for: $CHAIN_SPEC"
+echo "para_id:          ${PARA_ID}"
+echo "collator:         ${COLLATOR}"
+echo ""
+
+$COLLATOR build-spec --chain ${CHAIN_SPEC} >$DUMP_DIR/${CHAIN_SPEC}.json
+$COLLATOR build-spec --chain ${CHAIN_SPEC} --raw >$DUMP_DIR/${CHAIN_SPEC}-raw.json
+sed -i "/\"para_id\": 2015/s/2015/${PARA_ID}/" $DUMP_DIR/${CHAIN_SPEC}.json
+sed -i "/\"para_id\": 2015/s/2015/${PARA_ID}/" $DUMP_DIR/${CHAIN_SPEC}-raw.json
+
+$COLLATOR export-genesis-state --chain $DUMP_DIR/${CHAIN_SPEC}-raw.json --parachain-id ${PARA_ID} >$DUMP_DIR/${CHAIN_SPEC}.state
+$COLLATOR export-genesis-wasm --chain $DUMP_DIR/${CHAIN_SPEC}-raw.json >$DUMP_DIR/${CHAIN_SPEC}.wasm


### PR DESCRIPTION
When trying to launch a parachain with an older wasm file that was created with our chain_dump script, I got the following error:

`Could not find the header of the genesis block in the database!`

It turned out that we used the wrong approach when creating chain_specs.

With this fix, I was able to register a parachain with wasm and state produced by this collator: https://github.com/integritee-network/parachain/actions/runs/1009059544

And then successfully produce blocks with this collator: https://github.com/integritee-network/parachain/commit/c020713dd11a10d86502ab457fa5e693a44342f5

Edit: Tested runtime upgrade.