### PR TITLE
remove illegal lightSyncState property from chain spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,7 +1382,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1415,7 +1415,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1445,7 +1445,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "derive_more 0.99.16",
  "futures 0.3.18",
@@ -1512,7 +1512,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.18",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1564,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1629,7 +1629,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "proc-macro-crate 1.1.0",
  "proc-macro2 1.0.32",
@@ -1640,7 +1640,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1692,7 +1692,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1742,7 +1742,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-collator"
-version = "1.2.11"
+version = "1.3.11"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-runtime"
-version = "1.2.11"
+version = "1.3.11"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -5930,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
+source = "git+https://github.com/paritytech/cumulus.git?branch=polkadot-v0.9.13#0be8e8fc214641e306e4f913dd64ff1913e46e95"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9584,7 +9584,7 @@ dependencies = [
 
 [[package]]
 name = "shell-runtime"
-version = "1.2.1"
+version = "1.3.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-collator"
 description = "The Integritee parachain collator binary"
 # align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.2.11"
+version = "1.3.11"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'integritee-runtime'
 description = "The Integritee parachain runtime"
 # patch revision must match runtime spec_version
-version = '1.2.11'
+version = '1.3.11'
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/res/integritee-westend.json
+++ b/polkadot-parachains/res/integritee-westend.json
@@ -15,7 +15,6 @@
   "relay_chain": "westend",
   "para_id": 2081,
   "consensusEngine": null,
-  "lightSyncState": null,
   "codeSubstitutes": {},
   "genesis": {
     "raw": {

--- a/polkadot-parachains/res/shell-westend.json
+++ b/polkadot-parachains/res/shell-westend.json
@@ -15,7 +15,6 @@
   "relay_chain": "westend",
   "para_id": 2081,
   "consensusEngine": null,
-  "lightSyncState": null,
   "codeSubstitutes": {},
   "genesis": {
     "raw": {

--- a/polkadot-parachains/shell-runtime/Cargo.toml
+++ b/polkadot-parachains/shell-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'shell-runtime'
 description = "The Integritee shell parachain runtime"
 # major.minor revision must match collator node. patch should stay at zero to match spec_version which is hard-nailed to 1
-version = '1.2.1'
+version = '1.3.1'
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"


### PR DESCRIPTION
fix the following error when connecting to westend:
```
Error: Input("Error parsing spec file: unknown field lightSyncState at line 53 column 1")
```
strangely, this was only present in westend configs

bump crate versions to 1.3.11