### PR TITLE
Unify formatting with cumulus and encointer

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,23 @@
-hard_tabs=true
-imports_granularity= "Crate"
+# Basic
+hard_tabs = true
+max_width = 100
+use_small_heuristics = "Max"
+
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+
+# Consistency
+newline_style = "Unix"
+
+# Misc
+binop_separator = "Back"
+chain_width = 80
+match_arm_blocks = false
+match_arm_leading_pipes = "Preserve"
+match_block_trailing_comma = true
+reorder_impl_items = false
+spaces_around_ranges = false
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = '2021'
 serde = { version = "1.0.132", default-features = false, optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
-parachain-info = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
+parachain-info = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
 # Substrate dependencies
@@ -43,14 +43,14 @@ pallet-aura = { git = "https://github.com/paritytech/substrate", default-feature
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.16" }
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.16" }

--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -123,10 +123,7 @@ pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-	NativeVersion {
-		runtime_version: VERSION,
-		can_author_with: Default::default(),
-	}
+	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers.

--- a/polkadot-parachains/shell-runtime/Cargo.toml
+++ b/polkadot-parachains/shell-runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = '2021'
 serde = { version = "1.0.132", optional = true, features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "2.3.1", default-features = false, features = ["derive"] }
 log = { version = "0.4.14", default-features = false }
-parachain-info = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
+parachain-info = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
 scale-info = { version = "1.0", default-features = false, features = ["derive"] }
 
 # Substrate dependencies
@@ -43,13 +43,13 @@ pallet-vesting = { git = "https://github.com/paritytech/substrate", default-feat
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.16" }
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus.git",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-aura-ext = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/paritytech/cumulus",  branch = "polkadot-v0.9.16", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.16" }

--- a/polkadot-parachains/shell-runtime/src/lib.rs
+++ b/polkadot-parachains/shell-runtime/src/lib.rs
@@ -106,10 +106,7 @@ pub const PRIMARY_PROBABILITY: (u64, u64) = (1, 4);
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-	NativeVersion {
-		runtime_version: VERSION,
-		can_author_with: Default::default(),
-	}
+	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 /// We assume that ~5% of the block weight is consumed by `on_initialize` handlers.

--- a/polkadot-parachains/src/chain_spec.rs
+++ b/polkadot-parachains/src/chain_spec.rs
@@ -109,16 +109,10 @@ pub fn shell_chain_spec(
 	relay_chain: RelayChain,
 ) -> ShellChainSpec {
 	let (root, endowed, authorities) = match genesis_keys {
-		GenesisKeys::Integritee => (
-			IntegriteeKeys::root(),
-			vec![IntegriteeKeys::root()],
-			IntegriteeKeys::authorities(),
-		),
-		GenesisKeys::WellKnown => (
-			WellKnownKeys::root(),
-			WellKnownKeys::endowed(),
-			WellKnownKeys::authorities(),
-		),
+		GenesisKeys::Integritee =>
+			(IntegriteeKeys::root(), vec![IntegriteeKeys::root()], IntegriteeKeys::authorities()),
+		GenesisKeys::WellKnown =>
+			(WellKnownKeys::root(), WellKnownKeys::endowed(), WellKnownKeys::authorities()),
 	};
 
 	let chain_name = "Integritee Shell".to_string();
@@ -138,16 +132,10 @@ pub fn integritee_chain_spec(
 	relay_chain: RelayChain,
 ) -> IntegriteeChainSpec {
 	let (root, endowed, authorities) = match genesis_keys {
-		GenesisKeys::Integritee => (
-			IntegriteeKeys::root(),
-			vec![IntegriteeKeys::root()],
-			IntegriteeKeys::authorities(),
-		),
-		GenesisKeys::WellKnown => (
-			WellKnownKeys::root(),
-			WellKnownKeys::endowed(),
-			WellKnownKeys::authorities(),
-		),
+		GenesisKeys::Integritee =>
+			(IntegriteeKeys::root(), vec![IntegriteeKeys::root()], IntegriteeKeys::authorities()),
+		GenesisKeys::WellKnown =>
+			(WellKnownKeys::root(), WellKnownKeys::endowed(), WellKnownKeys::authorities()),
 	};
 
 	let chain_name = "Integritee Network".to_string();
@@ -191,10 +179,7 @@ fn chain_spec<F: Fn() -> GenesisConfig + 'static + Send + Sync, GenesisConfig>(
 			)
 			.unwrap(),
 		),
-		Extensions {
-			relay_chain: relay_chain.into(),
-			para_id: para_id.into(),
-		},
+		Extensions { relay_chain: relay_chain.into(), para_id: para_id.into() },
 	)
 }
 
@@ -217,14 +202,10 @@ fn integritee_genesis_config(
 				.map(|k| (k, 10_000_000__000_000_000_000))
 				.collect(),
 		},
-		sudo: parachain_runtime::SudoConfig {
-			key: Some(root_key),
-		},
+		sudo: parachain_runtime::SudoConfig { key: Some(root_key) },
 		vesting: Default::default(),
 		parachain_info: parachain_runtime::ParachainInfoConfig { parachain_id: id },
-		aura: parachain_runtime::AuraConfig {
-			authorities: initial_authorities,
-		},
+		aura: parachain_runtime::AuraConfig { authorities: initial_authorities },
 		aura_ext: Default::default(),
 		parachain_system: Default::default(),
 	}
@@ -249,15 +230,11 @@ fn shell_genesis_config(
 				.map(|k| (k, 10_000_000__000_000_000_000))
 				.collect(),
 		},
-		sudo: shell_runtime::SudoConfig {
-			key: Some(root_key),
-		},
+		sudo: shell_runtime::SudoConfig { key: Some(root_key) },
 		vesting: Default::default(),
 		parachain_info: shell_runtime::ParachainInfoConfig { parachain_id },
 		parachain_system: Default::default(),
-		aura: shell_runtime::AuraConfig {
-			authorities: initial_authorities,
-		},
+		aura: shell_runtime::AuraConfig { authorities: initial_authorities },
 		aura_ext: Default::default(),
 	}
 }

--- a/polkadot-parachains/src/cli.rs
+++ b/polkadot-parachains/src/cli.rs
@@ -135,14 +135,7 @@ impl RelayChainCli {
 	) -> Self {
 		let extension = chain_spec::Extensions::try_get(&*para_config.chain_spec);
 		let chain_id = extension.map(|e| e.relay_chain.clone());
-		let base_path = para_config
-			.base_path
-			.as_ref()
-			.map(|x| x.path().join("polkadot"));
-		Self {
-			base_path,
-			chain_id,
-			base: polkadot_cli::RunCmd::from_iter(relay_chain_args),
-		}
+		let base_path = para_config.base_path.as_ref().map(|x| x.path().join("polkadot"));
+		Self { base_path, chain_id, base: polkadot_cli::RunCmd::from_iter(relay_chain_args) }
 	}
 }

--- a/polkadot-parachains/src/command.rs
+++ b/polkadot-parachains/src/command.rs
@@ -242,27 +242,27 @@ pub fn run() -> Result<()> {
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
-		}
+		},
 		Some(Subcommand::CheckBlock(cmd)) => {
 			construct_async_run!(|components, cli, cmd, config| {
 				Ok(cmd.run(components.client, components.import_queue))
 			})
-		}
+		},
 		Some(Subcommand::ExportBlocks(cmd)) => {
 			construct_async_run!(|components, cli, cmd, config| {
 				Ok(cmd.run(components.client, config.database))
 			})
-		}
+		},
 		Some(Subcommand::ExportState(cmd)) => {
 			construct_async_run!(|components, cli, cmd, config| {
 				Ok(cmd.run(components.client, config.chain_spec))
 			})
-		}
+		},
 		Some(Subcommand::ImportBlocks(cmd)) => {
 			construct_async_run!(|components, cli, cmd, config| {
 				Ok(cmd.run(components.client, components.import_queue))
 			})
-		}
+		},
 		Some(Subcommand::PurgeChain(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 
@@ -283,7 +283,7 @@ pub fn run() -> Result<()> {
 
 				cmd.run(config, polkadot_config)
 			})
-		}
+		},
 		Some(Subcommand::Revert(cmd)) => construct_async_run!(|components, cli, cmd, config| {
 			Ok(cmd.run(components.client, components.backend))
 		}),
@@ -310,7 +310,7 @@ pub fn run() -> Result<()> {
 			}
 
 			Ok(())
-		}
+		},
 		Some(Subcommand::ExportGenesisWasm(params)) => {
 			let mut builder = sc_cli::LoggerBuilder::new("");
 			builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
@@ -331,8 +331,8 @@ pub fn run() -> Result<()> {
 			}
 
 			Ok(())
-		}
-		Some(Subcommand::Benchmark(cmd)) => {
+		},
+		Some(Subcommand::Benchmark(cmd)) =>
 			if cfg!(feature = "runtime-benchmarks") {
 				let runner = cli.create_runner(cmd)?;
 				if runner.config().chain_spec.is_shell() {
@@ -347,8 +347,7 @@ pub fn run() -> Result<()> {
 				Err("Benchmarking wasn't enabled when building the node. \
 				You can enable it with `--features runtime-benchmarks`."
 					.into())
-			}
-		}
+			},
 		Some(Subcommand::Key(cmd)) => Ok(cmd.run(&cli)?),
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
@@ -386,14 +385,7 @@ pub fn run() -> Result<()> {
 				info!("Parachain id: {:?}", id);
 				info!("Parachain Account: {}", parachain_account);
 				info!("Parachain genesis state: {}", genesis_state);
-				info!(
-					"Is collating: {}",
-					if config.role.is_authority() {
-						"yes"
-					} else {
-						"no"
-					}
-				);
+				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
 
 				if config.chain_spec.is_shell() {
 					crate::service::start_parachain_node::<
@@ -415,7 +407,7 @@ pub fn run() -> Result<()> {
 					.map_err(Into::into)
 				}
 			})
-		}
+		},
 	}
 }
 
@@ -478,9 +470,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 		default_listen_port: u16,
 		chain_spec: &Box<dyn ChainSpec>,
 	) -> Result<Option<PrometheusConfig>> {
-		self.base
-			.base
-			.prometheus_config(default_listen_port, chain_spec)
+		self.base.base.prometheus_config(default_listen_port, chain_spec)
 	}
 
 	fn init<F>(
@@ -499,11 +489,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 	fn chain_id(&self, is_dev: bool) -> Result<String> {
 		let chain_id = self.base.base.chain_id(is_dev)?;
 
-		Ok(if chain_id.is_empty() {
-			self.chain_id.clone().unwrap_or_default()
-		} else {
-			chain_id
-		})
+		Ok(if chain_id.is_empty() { self.chain_id.clone().unwrap_or_default() } else { chain_id })
 	}
 
 	fn role(&self, is_dev: bool) -> Result<sc_service::Role> {

--- a/polkadot-parachains/src/rpc.rs
+++ b/polkadot-parachains/src/rpc.rs
@@ -61,20 +61,10 @@ where
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
-	let FullDeps {
-		client,
-		pool,
-		deny_unsafe,
-	} = deps;
+	let FullDeps { client, pool, deny_unsafe } = deps;
 
-	io.extend_with(SystemApi::to_delegate(FullSystem::new(
-		client.clone(),
-		pool,
-		deny_unsafe,
-	)));
-	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(
-		client.clone(),
-	)));
+	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
+	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
 
 	io
 }

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -181,9 +181,7 @@ where
 	let telemetry_worker_handle = telemetry.as_ref().map(|(worker, _)| worker.handle());
 
 	let telemetry = telemetry.map(|(worker, telemetry)| {
-		task_manager
-			.spawn_handle()
-			.spawn("telemetry", None, worker.run());
+		task_manager.spawn_handle().spawn("telemetry", None, worker.run());
 		telemetry
 	});
 
@@ -215,6 +213,7 @@ where
 
 	Ok(params)
 }
+
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
@@ -283,7 +282,7 @@ where
 	) -> Result<Box<dyn ParachainConsensus<Block>>, sc_service::Error>,
 {
 	if matches!(parachain_config.role, Role::Light) {
-		return Err("Light client not supported!".into());
+		return Err("Light client not supported!".into())
 	}
 
 	let parachain_config = prepare_node_config(parachain_config);
@@ -417,7 +416,7 @@ impl<R> BuildOnAccess<R> {
 			match self {
 				Self::Uninitialized(f) => {
 					*self = Self::Initialized((f.take().unwrap())());
-				}
+				},
 				Self::Initialized(ref mut r) => return r,
 			}
 		}
@@ -497,13 +496,7 @@ where
 	async fn verify(
 		&mut self,
 		block_import: BlockImportParams<Block, ()>,
-	) -> Result<
-		(
-			BlockImportParams<Block, ()>,
-			Option<Vec<(CacheKeyId, Vec<u8>)>>,
-		),
-		String,
-	> {
+	) -> Result<(BlockImportParams<Block, ()>, Option<Vec<(CacheKeyId, Vec<u8>)>>), String> {
 		let block_id = BlockId::hash(*block_import.header.parent_hash());
 
 		if self
@@ -557,34 +550,32 @@ where
 	let aura_verifier = move || {
 		let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client2).unwrap();
 
-		Box::new(cumulus_client_consensus_aura::build_verifier::<
-			<AuraId as AppKey>::Pair,
-			_,
-			_,
-			_,
-		>(cumulus_client_consensus_aura::BuildVerifierParams {
-			client: client2.clone(),
-			create_inherent_data_providers: move |_, _| async move {
-				let time = sp_timestamp::InherentDataProvider::from_system_time();
+		Box::new(
+			cumulus_client_consensus_aura::build_verifier::<<AuraId as AppKey>::Pair, _, _, _>(
+				cumulus_client_consensus_aura::BuildVerifierParams {
+					client: client2.clone(),
+					create_inherent_data_providers: move |_, _| async move {
+						let time = sp_timestamp::InherentDataProvider::from_system_time();
 
-				let slot =
+						let slot =
 					sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
 						*time,
 						slot_duration.slot_duration(),
 					);
 
-				Ok((time, slot))
-			},
-			can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(
-				client2.executor().clone(),
+						Ok((time, slot))
+					},
+					can_author_with: sp_consensus::CanAuthorWithNativeVersion::new(
+						client2.executor().clone(),
+					),
+					telemetry: telemetry_handle,
+				},
 			),
-			telemetry: telemetry_handle,
-		})) as Box<_>
+		) as Box<_>
 	};
 
-	let relay_chain_verifier = Box::new(RelayChainVerifier::new(client.clone(), |_, _| async {
-		Ok(())
-	})) as Box<_>;
+	let relay_chain_verifier =
+		Box::new(RelayChainVerifier::new(client.clone(), |_, _| async { Ok(()) })) as Box<_>;
 
 	let verifier = Verifier {
 		client: client.clone(),
@@ -657,7 +648,6 @@ where
 			let transaction_pool2 = transaction_pool.clone();
 			let telemetry2 = telemetry.clone();
 			let prometheus_registry2 = prometheus_registry.map(|r| (*r).clone());
-
 			let relay_chain_for_aura = relay_chain_interface.clone();
 			let aura_consensus = BuildOnAccess::Uninitialized(Some(Box::new(move || {
 				let slot_duration =
@@ -689,10 +679,10 @@ where
 										sp_timestamp::InherentDataProvider::from_system_time();
 
 									let slot =
-								sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
-									*time,
-									slot_duration.slot_duration(),
-								);
+									sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_duration(
+										*time,
+										slot_duration.slot_duration(),
+									);
 
 									let parachain_inherent =
 										parachain_inherent.ok_or_else(|| {
@@ -740,11 +730,11 @@ where
 								async move {
 									let parachain_inherent =
 									cumulus_primitives_parachain_inherent::ParachainInherentData::create_at(
-									relay_parent,
-									&relay_chain_interface,
-									&validation_data,
-									id,
-								).await;
+										relay_parent,
+										&relay_chain_interface,
+										&validation_data,
+										id,
+									).await;
 									let parachain_inherent =
 										parachain_inherent.ok_or_else(|| {
 											Box::<dyn std::error::Error + Send + Sync>::from(

--- a/polkadot-parachains/tests/polkadot_argument_parsing.rs
+++ b/polkadot-parachains/tests/polkadot_argument_parsing.rs
@@ -47,10 +47,7 @@ fn polkadot_argument_parsing() {
 			.unwrap();
 
 		thread::sleep(Duration::from_secs(20));
-		assert!(
-			cmd.try_wait().unwrap().is_none(),
-			"the process should still be running"
-		);
+		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
 		kill(Pid::from_raw(cmd.id().try_into().unwrap()), signal).unwrap();
 		assert_eq!(
 			common::wait_for(&mut cmd, 30).map(|x| x.success()),

--- a/polkadot-parachains/tests/polkadot_mdns_issue.rs
+++ b/polkadot-parachains/tests/polkadot_mdns_issue.rs
@@ -38,10 +38,7 @@ fn interrupt_polkadot_mdns_issue_test() {
 			.unwrap();
 
 		thread::sleep(Duration::from_secs(20));
-		assert!(
-			cmd.try_wait().unwrap().is_none(),
-			"the process should still be running"
-		);
+		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
 		kill(Pid::from_raw(cmd.id().try_into().unwrap()), signal).unwrap();
 		assert_eq!(
 			common::wait_for(&mut cmd, 30).map(|x| x.success()),

--- a/polkadot-parachains/tests/purge_chain_works.rs
+++ b/polkadot-parachains/tests/purge_chain_works.rs
@@ -39,16 +39,11 @@ fn purge_chain_works() {
 
 		// Let it produce some blocks.
 		thread::sleep(Duration::from_secs(30));
-		assert!(
-			cmd.try_wait().unwrap().is_none(),
-			"the process should still be running"
-		);
+		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
 
 		// Stop the process
 		kill(Pid::from_raw(cmd.id().try_into().unwrap()), SIGINT).unwrap();
-		assert!(common::wait_for(&mut cmd, 30)
-			.map(|x| x.success())
-			.unwrap_or_default());
+		assert!(common::wait_for(&mut cmd, 30).map(|x| x.success()).unwrap_or_default());
 
 		base_path
 	}
@@ -58,10 +53,7 @@ fn purge_chain_works() {
 		let base_path = run_node_and_stop();
 
 		assert!(base_path.path().join("chains/local_testnet/db").exists());
-		assert!(base_path
-			.path()
-			.join("polkadot/chains/westend_dev/db")
-			.exists());
+		assert!(base_path.path().join("polkadot/chains/westend_dev/db").exists());
 
 		let status = Command::new(cargo_bin("polkadot-collator"))
 			.args(&["purge-chain", "-d"])
@@ -74,13 +66,7 @@ fn purge_chain_works() {
 		// Make sure that the `parachain_local_testnet` chain folder exists, but the `db` is deleted.
 		assert!(base_path.path().join("chains/local_testnet").exists());
 		assert!(!base_path.path().join("chains/local_testnet/db").exists());
-		assert!(base_path
-			.path()
-			.join("polkadot/chains/westend_dev")
-			.exists());
-		assert!(!base_path
-			.path()
-			.join("polkadot/chains/westend_dev/db")
-			.exists());
+		assert!(base_path.path().join("polkadot/chains/westend_dev").exists());
+		assert!(!base_path.path().join("polkadot/chains/westend_dev/db").exists());
 	}
 }

--- a/polkadot-parachains/tests/running_the_node_and_interrupt.rs
+++ b/polkadot-parachains/tests/running_the_node_and_interrupt.rs
@@ -38,10 +38,7 @@ fn running_the_node_works_and_can_be_interrupted() {
 			.unwrap();
 
 		thread::sleep(Duration::from_secs(30));
-		assert!(
-			cmd.try_wait().unwrap().is_none(),
-			"the process should still be running"
-		);
+		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
 		kill(Pid::from_raw(cmd.id().try_into().unwrap()), signal).unwrap();
 		assert_eq!(
 			common::wait_for(&mut cmd, 30).map(|x| x.success()),


### PR DESCRIPTION
While debugging the OOM error, I checked diffs with encointer, where I noticed we don't have the same rustfmt configs.

For better cross-applying of code, I unified the fmt settings, which now also match upstream cumulus.