### PR TITLE
Improve XCM Config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-collator"
-version = "1.5.29"
+version = "1.5.30"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-runtime"
-version = "1.5.25"
+version = "1.5.26"
 dependencies = [
  "common",
  "cumulus-pallet-aura-ext",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-collator"
 description = "The Integritee parachain collator binary"
 # align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.5.29"
+version = "1.5.30"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'integritee-runtime'
 description = "The Integritee parachain runtime"
 # patch revision must match runtime spec_version
-version = '1.5.25'
+version = '1.5.26'
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -107,7 +107,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("integritee-parachain"),
 	impl_name: create_runtime_str!("integritee-full"),
 	authoring_version: 2,
-	spec_version: 25,
+	spec_version: 26,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 3,

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -264,7 +264,7 @@ pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNet
 // See acala and moonbeam example : https://github.com/integritee-network/parachain/issues/103
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
-	type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>; //We want to disallow users sending (arbitrary) XCMs from this chain
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>; // Prohibit sending arbitrary XCMs from users of this chain
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>; // Allow any local origin in XCM execution.
 	type XcmExecuteFilter = Nothing; // Disable generic XCM execution. This does not affect Teleport or Reserve Transfer.

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -266,7 +266,7 @@ impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>; //We want to disallow users sending (arbitrary) XCMs from this chain
 	type XcmRouter = XcmRouter;
-	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>; // Anyone can execute XCM messages locally...
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>; // Allow any local origin in XCM execution.
 	type XcmExecuteFilter = Nothing; // but disallow generic XCM execution. As a result only teleports and reserve transfers can be allowed.
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Nothing; // Do not allow teleports

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -28,7 +28,7 @@ use core::marker::PhantomData;
 use frame_support::{
 	pallet_prelude::Get,
 	parameter_types,
-	traits::Everything,
+	traits::{Everything, Nothing},
 	weights::{IdentityFee, Weight},
 	RuntimeDebug,
 };
@@ -49,9 +49,9 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
-	LocationInverter, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	LocationInverter, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -187,9 +187,6 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognised.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, Origin>,
-	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
-	// transaction from the Root origin.
-	ParentAsSuperuser<Origin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `Origin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, Origin>,
@@ -266,11 +263,11 @@ impl pallet_xcm::Config for Runtime {
 	type Event = Event;
 	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
-	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-	type XcmExecuteFilter = Everything;
+	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>; // Anyone can execute XCM messages locally...
+	type XcmExecuteFilter = Nothing; // but disallow generic XCM execution. As a result only teleports and reserve transfers can be allowed.
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type XcmTeleportFilter = Everything;
-	type XcmReserveTransferFilter = Everything;
+	type XcmTeleportFilter = Nothing; // Do not allow teleports
+	type XcmReserveTransferFilter = Everything; // Transfer are allowed
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -49,9 +49,9 @@ use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
-	LocationInverter, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
-	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	LocationInverter, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -187,6 +187,9 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native converter for sibling Parachains; will convert to a `SiblingPara` origin when
 	// recognised.
 	SiblingParachainAsNative<cumulus_pallet_xcm::Origin, Origin>,
+	// Superuser converter for the Relay-chain (Parent) location. This will allow it to issue a
+	// transaction from the Root origin.
+	ParentAsSuperuser<Origin>,
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `Origin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, Origin>,
@@ -261,7 +264,7 @@ pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, RelayNet
 // See acala and moonbeam example : https://github.com/integritee-network/parachain/issues/103
 impl pallet_xcm::Config for Runtime {
 	type Event = Event;
-	type SendXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
+	type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>; //We want to disallow users sending (arbitrary) XCMs from this chain
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>; // Anyone can execute XCM messages locally...
 	type XcmExecuteFilter = Nothing; // but disallow generic XCM execution. As a result only teleports and reserve transfers can be allowed.

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -267,7 +267,7 @@ impl pallet_xcm::Config for Runtime {
 	type SendXcmOrigin = EnsureXcmOrigin<Origin, ()>; //We want to disallow users sending (arbitrary) XCMs from this chain
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>; // Allow any local origin in XCM execution.
-	type XcmExecuteFilter = Nothing; // but disallow generic XCM execution. As a result only teleports and reserve transfers can be allowed.
+	type XcmExecuteFilter = Nothing; // Disable generic XCM execution. This does not affect Teleport or Reserve Transfer.
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Nothing; // Do not allow teleports
 	type XcmReserveTransferFilter = Everything; // Transfer are allowed


### PR DESCRIPTION
- Disallow generic XCM execution, do not allow teleport and allow transfer, according to task https://github.com/integritee-network/parachain/issues/117 
- Disallow users sending (arbitrary) XCMs from this chain, according to https://medium.com/kusama-network/kusamas-governance-thwarts-would-be-attacker-9023180f6fb

To undestand the different filter and check how to configure them: see https://blog.quarkslab.com/a-brief-overview-of-auditing-xcmv2.html

Tested: Filter changes still allow to manually open an HRMP channel with Acala's rococo parachain and transfer TEER token.
