### PR TITLE
Add skip-ias compiler flag

### DIFF
--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -109,6 +109,8 @@ substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate
 
 [features]
 default = []
+# allow workers to register without remote attestation for dev purposes
+skip-ias-check = ["parachain-runtime/skip-ias-check"]
 runtime-benchmarks = [
 	'polkadot-service/runtime-benchmarks',
 	'parachain-runtime/runtime-benchmarks'

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -96,6 +96,7 @@ substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", bran
 
 [features]
 default = [ "std" ]
+skip-ias-check = ["pallet-teerex/skip-ias-check"]
 std = [
 	"codec/std",
 	"serde/std",


### PR DESCRIPTION
Allows registering workers in the pallet-teerex without supplying remote attestation from Intel.

Now that we can also connect the worker to the parachain, it makes sense to have this dev-flag.