### PR TITLE
add `CheckNonZeroSender` to `SignedExtra`

### DIFF
--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -758,6 +758,7 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type BlockId = generic::BlockId<Block>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
+	frame_system::CheckNonZeroSender<Runtime>,
 	frame_system::CheckSpecVersion<Runtime>,
 	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,

--- a/polkadot-parachains/shell-runtime/src/lib.rs
+++ b/polkadot-parachains/shell-runtime/src/lib.rs
@@ -391,6 +391,7 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type BlockId = generic::BlockId<Block>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
+	frame_system::CheckNonZeroSender<Runtime>,
 	frame_system::CheckSpecVersion<Runtime>,
 	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,


### PR DESCRIPTION
* Closes #144 

To be aligned with the api-client and substrate.

It updates the extrinsic format so that we are again compatible with current worker state.