### PR TITLE
Add license check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,28 @@ jobs:
         if: ${{ matrix.check == 'clippy' }}
         run: cargo clippy -- -D warnings
 
+  license-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install cargo-about
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-about
+          version: "0.5"
+
+      - name: Run license check
+        # Explicitly use stable because otherwise cargo will trigger a download of
+        # the nightly version specified in rust-toolchain.toml
+        run: cargo +stable about generate about.hbs > license.html
+
+      - name: Archive license file
+        uses: actions/upload-artifact@v3
+        with:
+          name: license
+          path: license.html
+
   cargo-toml-fmt:
     runs-on: ubuntu-latest
     container: "tamasfe/taplo:0.7.0-alpine"

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,70 @@
+<html>
+
+<head>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="container">
+        <div class="intro">
+            <h1>Third Party Licenses</h1>
+            <p>This page lists the licenses of the projects used in cargo-about.</p>
+        </div>
+    
+        <h2>Overview of licenses:</h2>
+        <ul class="licenses-overview">
+            {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+            {{/each}}
+        </ul>
+
+        <h2>All license text:</h2>
+        <ul class="licenses-list">
+            {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                    <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+            {{/each}}
+        </ul>
+    </main>
+</body>
+
+</html>

--- a/about.hbs
+++ b/about.hbs
@@ -39,7 +39,7 @@
     <main class="container">
         <div class="intro">
             <h1>Third Party Licenses</h1>
-            <p>This page lists the licenses of the projects used in cargo-about.</p>
+            <p>This page lists the licenses of the projects used in 'Integritee Networks Parachain' repository. </p>
         </div>
     
         <h2>Overview of licenses:</h2>

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,20 @@
+accepted = [
+    "Apache-2.0",
+    "MIT",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "CC0-1.0",
+    "BSD-3-Clause",
+    "MPL-2.0",
+    "ISC",
+    "OpenSSL",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "GPL-3.0 WITH Classpath-exception-2.0",
+    "GPL-3.0",
+]
+ignore-dev-dependencies = true
+ignore-build-dependencies = true
+workarounds = [
+    "ring",
+]


### PR DESCRIPTION
- Similar to the PR for the pallets repo
  - https://github.com/integritee-network/pallets/pull/98
- Note that parachain is already licensed under GPL-3.0
- Unfortunately the generated license.html does not mention the classpath exception
  - See https://github.com/EmbarkStudios/cargo-about/issues/204
  - If we want to use it as part of a binary release we probably should modify it manually
- The license check takes quite some time (3 min), but I cannot reproduce this on my machine. There it takes seconds
  - The parachain build already takes a while so it's not that important, but for other repos this can be annoying.