### PR TITLE
Update runtime-upload path to fix runtime publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
         id: srtool_build
         uses: chevdor/srtool-actions@v0.6.0
         with:
+          image: paritytech/srtool
           chain: ${{ matrix.runtime }}
           runtime_dir: polkadot-parachains/${{ matrix.runtime }}-runtime
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,9 +208,7 @@ jobs:
         with:
           name: ${{ matrix.runtime }}-runtime-${{ github.sha }}
           path: |
-            ${{ steps.srtool_build.outputs.wasm }}
             ${{ steps.srtool_build.outputs.wasm_compressed }}
-            ${{ matrix.runtime }}-srtool-digest.json
 
       # We now get extra information thanks to subwasm
       - name: Install subwasm
@@ -222,9 +220,7 @@ jobs:
       - name: Show Runtime information
         shell: bash
         run: |
-          subwasm info ${{ steps.srtool_build.outputs.wasm }}
           subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
-          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.runtime }}-info.json
           subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.runtime }}-compressed-info.json
 
       - name: Extract the metadata
@@ -245,6 +241,7 @@ jobs:
         with:
           name: ${{ matrix.runtime }}-srtool-json-${{ github.sha }}
           path: |
+            ${{ matrix.runtime }}-srtool-digest.json
             ${{ matrix.runtime }}-info.json
             ${{ matrix.runtime }}-compressed-info.json
             ${{ matrix.runtime }}-metadata.json


### PR DESCRIPTION
This puts the runtime in the top-level folder again, and fixes the publishing of the runtimes in the release process.