### PR TITLE
Get configurable xcm params for the slow swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,7 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -954,7 +954,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "sp-std",
 ]
@@ -3232,7 +3232,7 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "base64",
  "chrono",
@@ -5345,7 +5345,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -5871,7 +5871,7 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5984,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6210,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-transactor"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -9952,7 +9952,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11229,7 +11229,7 @@ checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -11239,7 +11239,7 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "ias-verify",
  "parity-scale-codec",
@@ -11282,7 +11282,7 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "hex-literal",
  "log",
@@ -12748,7 +12748,7 @@ dependencies = [
 [[package]]
 name = "xcm-transactor-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#38d6995aac434d46df47bb55fcb99cd11a4c59fc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.36#ef51a5548178896d11deaccc2f8b29702c190863"
 dependencies = [
  "common-primitives",
  "cumulus-primitives-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-collator"
-version = "1.5.32"
+version = "1.5.33"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-runtime"
-version = "1.5.28"
+version = "1.5.29"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -9890,7 +9890,7 @@ dependencies = [
 
 [[package]]
 name = "shell-runtime"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-collator"
 description = "The Integritee parachain collator binary"
 # align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.5.32"
+version = "1.5.33"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-runtime"
 description = "The Integritee parachain runtime"
 # patch revision must match runtime spec_version
-version = "1.5.28"
+version = "1.5.29"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -101,10 +101,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("integritee-parachain"),
 	impl_name: create_runtime_str!("integritee-full"),
 	authoring_version: 2,
-	spec_version: 28,
+	spec_version: 29,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -46,7 +46,7 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
-use xcm::latest::{prelude::*, Weight as XcmWeight};
+use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
@@ -284,7 +284,6 @@ impl pallet_xcm::Config for Runtime {
 parameter_types! {
 	pub const ShellRuntimeParaId: u32 = 2223u32;
 	pub const IntegriteeKsmParaId: u32 = 2015u32;
-	pub const WeightForParaSwap: XcmWeight = 10_000_000_000;
 }
 
 impl pallet_xcm_transactor::Config for Runtime {
@@ -294,7 +293,6 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type SwapOrigin = EnsureRootOrMoreThanHalfCouncil;
 	type ShellRuntimeParaId = ShellRuntimeParaId;
 	type IntegriteeKsmParaId = IntegriteeKsmParaId;
-	type WeightForParaSwap = WeightForParaSwap;
 	type WeightInfo = ();
 }
 

--- a/polkadot-parachains/shell-runtime/Cargo.toml
+++ b/polkadot-parachains/shell-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shell-runtime"
 description = "The Integritee shell parachain runtime"
 # major.minor revision must match collator node. patch should match spec_version
-version = "1.5.6"
+version = "1.5.7"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/shell-runtime/src/lib.rs
+++ b/polkadot-parachains/shell-runtime/src/lib.rs
@@ -79,10 +79,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("integritee-parachain"),
 	impl_name: create_runtime_str!("integritee-shell"),
 	authoring_version: 0,
-	spec_version: 6,
+	spec_version: 7,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 0,
+	transaction_version: 1,
 	state_version: 0,
 };
 

--- a/polkadot-parachains/shell-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/shell-runtime/src/xcm_config.rs
@@ -46,7 +46,7 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
-use xcm::latest::{prelude::*, Weight as XcmWeight};
+use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds,
@@ -284,7 +284,6 @@ impl pallet_xcm::Config for Runtime {
 parameter_types! {
 	pub const IntegriteeKsmParaId: u32 = 2015;
 	pub const ShellRuntimeParaId: u32 = 2223;
-	pub const WeightForParaSwap: XcmWeight = 10_000_000_000;
 }
 
 impl pallet_xcm_transactor::Config for Runtime {
@@ -294,7 +293,6 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type SwapOrigin = EnsureRoot<AccountId>;
 	type ShellRuntimeParaId = ShellRuntimeParaId;
 	type IntegriteeKsmParaId = IntegriteeKsmParaId;
-	type WeightForParaSwap = WeightForParaSwap;
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
We had the issue that our slot swap was successful on the rococo-local setup, but it failed on the actual Kusama chain because the Kusama's XCM settings are different. As the XCM settings were hardcoded in the call, we have to do a runtime upgrade to fix this. However, we use this situation to make the XCM params configurable as call arguments so that we never run into the issue again.

## Changes
* bump integritee-pallets
* change runtime spec versions and transaction version, as the swap call has changed.
* bump collator version