### PR TITLE
GHA: Node.js 12 / `set-output` deprecation fixes

### DIFF
--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Set output
         id: vars
-        run: echo "tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
+        run: echo "{tag}={${GITHUB_REF#refs/*/}}" >> $GITHUB_OUTPUT
 
       - name: Check output
         env:

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
         uses: actions/cache@v3

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build and push
         id:   docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: true
           context: .


### PR DESCRIPTION
This PR aims to get rid of the deprecation warnings in the CI.

There should be no deprecation warning for this PR run, please check before merging.

Fixes #191.