### PR TITLE
[integritee-runtime] fix slot swap config

### DIFF
--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -324,7 +324,7 @@ impl pallet_xcm::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ShellRuntimeParaId: u32 = 2223u32;
+	pub const ShellRuntimeParaId: u32 = 2267u32;
 	pub const IntegriteeKsmParaId: u32 = 2015u32;
 }
 


### PR DESCRIPTION
* Closes #225 

Successfully tested a rococo-local-dev slot swap according to the following protocol: https://github.com/integritee-network/parachain/issues/222#issuecomment-1625604991

After this one, we can release a new version, and we can do the runtime upgrade https://github.com/integritee-network/parachain/issues/219