### PR TITLE
[GHA] fix deprecated cargo install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install cargo-about
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v2
         with:
           crate: cargo-about
-          version: "0.5"
+          version: "0.5.6"
 
       - name: Run license check
         # Explicitly use stable because otherwise cargo will trigger a download of


### PR DESCRIPTION
GitHub actions has now definitely removed the support for node v12, which is why the action fails. This PR fixes this by a simple update of the `cargo-install` action.