### PR TITLE
fix docker build by using ubuntu-22.04 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0
+FROM phusion/baseimage:jammy-1.0.1
 LABEL maintainer="zoltan@integritee.network"
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 


### PR DESCRIPTION
As of https://github.com/integritee-network/parachain/pull/233 the CI builds on ubuntu-22.04, which breaks the docker build currently because it still uses the 20.04.