### PR TITLE
bump runtime to v38. bump pallets to report all possible DCAP SgxStatuses, allowing "outdated"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "common-primitives",
  "log",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-collator"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -3903,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-runtime"
-version = "1.6.37"
+version = "1.6.38"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -6054,7 +6054,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -6180,7 +6180,7 @@ dependencies = [
 [[package]]
 name = "pallet-enclave-bridge"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6740,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-transactor"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "sgx-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -11071,7 +11071,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12364,7 +12364,7 @@ checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -12374,7 +12374,7 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "common-primitives",
  "derive_more",
@@ -12418,7 +12418,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "log",
  "sgx-verify",
@@ -14357,7 +14357,7 @@ dependencies = [
 [[package]]
 name = "xcm-transactor-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#b07c044856aca63b5e07a401da676fffaadae48a"
 dependencies = [
  "common-primitives",
  "cumulus-primitives-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -1103,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "common-primitives",
  "log",
@@ -6054,7 +6054,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -6180,7 +6180,7 @@ dependencies = [
 [[package]]
 name = "pallet-enclave-bridge"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6716,7 +6716,7 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6740,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-transactor"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "sgx-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -11071,7 +11071,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12364,7 +12364,7 @@ checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -12374,7 +12374,7 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "common-primitives",
  "derive_more",
@@ -12418,7 +12418,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "log",
  "sgx-verify",
@@ -14357,7 +14357,7 @@ dependencies = [
 [[package]]
 name = "xcm-transactor-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.42#a211a704076c1844d1bb8783cbaec23bf80441f9"
 dependencies = [
  "common-primitives",
  "cumulus-primitives-core",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-collator"
 description = "The Integritee parachain collator binary"
 # align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-runtime"
 description = "The Integritee parachain runtime"
 # patch revision must match runtime spec_version
-version = "1.6.37"
+version = "1.6.38"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -104,7 +104,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("integritee-parachain"),
 	impl_name: create_runtime_str!("integritee-full"),
 	authoring_version: 2,
-	spec_version: 37,
+	spec_version: 38,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,
@@ -808,7 +808,10 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem, // Solochain: AllPalletsReversedWithSystemFirst, Statemint: AllPallets. Which one to take?
-	(pallet_teerex::migrations::v1::MigrateV0toV1<Runtime>,),
+	(
+		pallet_teerex::migrations::v1::MigrateV0toV1<Runtime>,
+		pallet_teerex::migrations::v2::MigrateV1toV2<Runtime>,
+	),
 >;
 
 #[cfg(feature = "runtime-benchmarks")]


### PR DESCRIPTION
integrates https://github.com/integritee-network/pallets/pull/225

* teerex will perform storage migration to V2!