### PR TITLE
naming shell -> mainnet and bump collator version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-collator"
-version = "1.7.6"
+version = "1.7.7"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -2,7 +2,7 @@
 name = "integritee-collator"
 description = "The Integritee parachain collator binary"
 # align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.7.6"
+version = "1.7.7"
 authors = ["Integritee AG <hello@integritee.network>"]
 homepage = "https://integritee.network/"
 repository = "https://github.com/integritee-network/parachain"

--- a/polkadot-parachains/chain-specs/integritee-polkadot.json
+++ b/polkadot-parachains/chain-specs/integritee-polkadot.json
@@ -37,7 +37,7 @@
     }
   },
   "id": "integritee-polkadot",
-  "name": "Integritee Shell",
+  "name": "Integritee Network (Polkadot)",
   "para_id": 2039,
   "properties": {
     "ss58Format": 13,


### PR DESCRIPTION
we have upgraded shell to full runtime on polkadot. 
This PR changes the naming for the polkadot spec to be reflected in UI's