### PR TITLE
cleanup workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,6 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -946,7 +945,6 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -2269,7 +2267,6 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "common-primitives",
  "log",
@@ -5769,7 +5766,6 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -5896,7 +5892,6 @@ dependencies = [
 [[package]]
 name = "pallet-enclave-bridge"
 version = "0.12.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6328,7 +6323,6 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.11.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6458,7 +6452,6 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6482,7 +6475,6 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6692,7 +6684,6 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-transactor"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10553,7 +10544,6 @@ dependencies = [
 [[package]]
 name = "sgx-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -10708,7 +10698,6 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11989,7 +11978,6 @@ checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -11999,7 +11987,6 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "common-primitives",
  "derive_more",
@@ -12043,7 +12030,6 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "log",
  "sgx-verify",
@@ -13669,7 +13655,6 @@ dependencies = [
 [[package]]
 name = "xcm-transactor-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#bd3e07a819eecae24ebeac8ef79efc7ff568ddad"
 dependencies = [
  "common-primitives",
  "cumulus-primitives-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,6 +814,7 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
@@ -945,6 +946,7 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -2267,6 +2269,7 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "common-primitives",
  "log",
@@ -5766,6 +5769,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "claims-primitives",
  "frame-benchmarking",
@@ -5892,6 +5896,7 @@ dependencies = [
 [[package]]
 name = "pallet-enclave-bridge"
 version = "0.12.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6323,6 +6328,7 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.11.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-benchmarking",
@@ -6452,6 +6458,7 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6475,6 +6482,7 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.10.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6684,6 +6692,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-transactor"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10544,6 +10553,7 @@ dependencies = [
 [[package]]
 name = "sgx-verify"
 version = "0.1.4"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -10698,6 +10708,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11978,6 +11989,7 @@ checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -11987,6 +11999,7 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "common-primitives",
  "derive_more",
@@ -12030,6 +12043,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 [[package]]
 name = "test-utils"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "log",
  "sgx-verify",
@@ -13655,6 +13669,7 @@ dependencies = [
 [[package]]
 name = "xcm-transactor-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v1.0.0#fc2999af866276658879555dcf5582bd1dba908e"
 dependencies = [
  "common-primitives",
  "cumulus-primitives-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 resolver = "2"
 members = [
     "polkadot-parachains",
+    "polkadot-parachains/common",
     "polkadot-parachains/integritee-runtime",
     "polkadot-parachains/shell-runtime",
-    "polkadot-parachains/common",
 ]
 
 [profile.release]
@@ -64,6 +64,7 @@ pallet-multisig = { default-features = false, git = "https://github.com/parityte
 pallet-preimage = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 pallet-proxy = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
@@ -149,7 +150,6 @@ tokio = { version = "1.23.0", features = ["macros", "time", "parking_lot"] }
 wait-timeout = "0.2"
 hex = "0.4.3"
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 
@@ -157,20 +157,20 @@ substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 
-[patch."https://github.com/integritee-network/pallets.git"]
-pallet-claims = { path = '../pallets/claims' }
-pallet-enclave-bridge = { path = '../pallets/enclave-bridge' }
-pallet-teerex = { path = '../pallets/teerex' }
-pallet-sidechain = { path = '../pallets/sidechain' }
-sgx-verify = { path = '../pallets/teerex/sgx-verify' }
-pallet-teeracle = { path = '../pallets/teeracle' }
-claims-primitives = { path = '../pallets/primitives/claims' }
-enclave-bridge-primitives = { path = '../pallets/primitives/enclave-bridge' }
-teerex-primitives = { path = '../pallets/primitives/teerex' }
-teeracle-primitives = { path = '../pallets/primitives/teeracle' }
-common-primitives = { path = '../pallets/primitives/common' }
-xcm-transactor-primitives = { path = '../pallets/primitives/xcm-transactor' }
-pallet-xcm-transactor = { path = '../pallets/xcm-transactor' }
+#[patch."https://github.com/integritee-network/pallets.git"]
+#pallet-claims = { path = '../pallets/claims' }
+#pallet-enclave-bridge = { path = '../pallets/enclave-bridge' }
+#pallet-teerex = { path = '../pallets/teerex' }
+#pallet-sidechain = { path = '../pallets/sidechain' }
+#sgx-verify = { path = '../pallets/teerex/sgx-verify' }
+#pallet-teeracle = { path = '../pallets/teeracle' }
+#claims-primitives = { path = '../pallets/primitives/claims' }
+#enclave-bridge-primitives = { path = '../pallets/primitives/enclave-bridge' }
+#teerex-primitives = { path = '../pallets/primitives/teerex' }
+#teeracle-primitives = { path = '../pallets/primitives/teeracle' }
+#common-primitives = { path = '../pallets/primitives/common' }
+#xcm-transactor-primitives = { path = '../pallets/primitives/xcm-transactor' }
+#pallet-xcm-transactor = { path = '../pallets/xcm-transactor' }
 
 [patch.crates-io]
 ring = { git = "https://github.com/betrusted-io/ring-xous", branch = "0.16.20-cleanup" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,168 @@ members = [
 
 [profile.release]
 panic = "unwind"
-#
-#[patch."https://github.com/integritee-network/pallets.git"]
-#pallet-claims = { path = '../pallets/claims' }
-#pallet-enclave-bridge = { path = '../pallets/enclave-bridge' }
-#pallet-teerex = { path = '../pallets/teerex' }
-#pallet-sidechain = { path = '../pallets/sidechain' }
-#sgx-verify = { path = '../pallets/teerex/sgx-verify' }
-#pallet-teeracle = { path = '../pallets/teeracle' }
-#test-utils = { path = '../pallets/test-utils' }
-#claims-primitives = { path = '../pallets/primitives/claims' }
-#enclave-bridge-primitives = { path = '../pallets/primitives/enclave-bridge' }
-#teerex-primitives = { path = '../pallets/primitives/teerex' }
-#teeracle-primitives = { path = '../pallets/primitives/teeracle' }
-#common-primitives = { path = '../pallets/primitives/common' }
+
+[workspace.dependencies]
+async-trait = "0.1.59"
+clap = { version = "4.0.29", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.6.1" }
+color-print = "0.3.4"
+futures = "0.3.25"
+hex-literal = "0.3.4"
+log = { version = "0.4.17", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.171", features = ["derive"] }
+serde_json = "1.0.102"
+smallvec = "1.9.0"
+
+# integritee pallets
+pallet-claims = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+pallet-enclave-bridge = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+pallet-sidechain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+pallet-teeracle = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+pallet-teerex = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+pallet-xcm-transactor = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+xcm-transactor-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+
+# Polkadot-sdk and ecosystem crates [no_std]
+cumulus-pallet-aura-ext = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-pallet-dmp-queue = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-pallet-parachain-system = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-pallet-xcm = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-pallet-xcmp-queue = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-primitives-timestamp = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-primitives-utility = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-system-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v1.0.0" }
+orml-traits = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
+orml-xcm = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
+orml-xcm-support = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
+orml-xtokens = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
+pallet-assets = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-bounties = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-child-bounties = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-collective = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-democracy = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-multisig = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-preimage = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-proxy = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-treasury = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-utility = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
+pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+parachain-info = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+polkadot-core-primitives = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+polkadot-parachain = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+polkadot-primitives = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+polkadot-runtime-common = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+sp-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-inherents = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-offchain = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-transaction-pool = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-version = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+xcm-builder = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+xcm-executor = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+
+# std stuff
+cumulus-client-cli = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-client-consensus-aura = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-client-consensus-relay-chain = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-client-network = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-client-service = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+jsonrpsee = { version = "0.16.2", features = ["server"] }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-consensus-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-network-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-network-sync = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-sysinfo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-state-trie-migration-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+
+# Temporary pin only
+# See https://github.com/bluejekyll/trust-dns/issues/1946 for more details.
+enum-as-inner = "=0.5.1"
+
+# dev dependencies
+assert_cmd = "2.0"
+nix = "0.25"
+tempfile = "3.3.0"
+tokio = { version = "1.23.0", features = ["macros", "time", "parking_lot"] }
+wait-timeout = "0.2"
+hex = "0.4.3"
+polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+
+# build dependencies
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+
+[patch."https://github.com/integritee-network/pallets.git"]
+pallet-claims = { path = '../pallets/claims' }
+pallet-enclave-bridge = { path = '../pallets/enclave-bridge' }
+pallet-teerex = { path = '../pallets/teerex' }
+pallet-sidechain = { path = '../pallets/sidechain' }
+sgx-verify = { path = '../pallets/teerex/sgx-verify' }
+pallet-teeracle = { path = '../pallets/teeracle' }
+claims-primitives = { path = '../pallets/primitives/claims' }
+enclave-bridge-primitives = { path = '../pallets/primitives/enclave-bridge' }
+teerex-primitives = { path = '../pallets/primitives/teerex' }
+teeracle-primitives = { path = '../pallets/primitives/teeracle' }
+common-primitives = { path = '../pallets/primitives/common' }
+xcm-transactor-primitives = { path = '../pallets/primitives/xcm-transactor' }
+pallet-xcm-transactor = { path = '../pallets/xcm-transactor' }
 
 [patch.crates-io]
 ring = { git = "https://github.com/betrusted-io/ring-xous", branch = "0.16.20-cleanup" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ panic = "unwind"
 [workspace.dependencies]
 async-trait = "0.1.59"
 clap = { version = "4.0.29", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
+parity-scale-codec = { default-features = false, version = "3.6.1", features = ["derive"] }
 color-print = "0.3.4"
 futures = "0.3.25"
 hex-literal = "0.3.4"
@@ -47,7 +47,7 @@ frame-support = { default-features = false, git = "https://github.com/paritytech
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 frame-system-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
 frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v1.0.0" }
+frame-try-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
 orml-traits = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
 orml-xcm = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
 orml-xcm-support = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -16,10 +16,10 @@ path = "src/main.rs"
 [dependencies]
 async-trait = { workspace = true }
 clap = { workspace = true }
-parity-scale-codec = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
 log = { workspace = true, features = ["std"] }
+parity-scale-codec = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
@@ -104,20 +104,16 @@ substrate-build-script-utils = { workspace = true }
 [dev-dependencies]
 assert_cmd = { workspace = true }
 nix = { workspace = true }
+pallet-sudo = { workspace = true, features = ["std"] }
+polkadot-cli = { workspace = true, features = ["rococo-native"]} # purge_chain_works works with rococo-local and needs to allow this
+substrate-test-client = { workspace = true }
+substrate-test-runtime-client = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 wait-timeout = { workspace = true }
-# purge_chain_works works with rococo-local and needs to allow this
-polkadot-cli = { workspace = true, features = ["rococo-native"]}
-
-# Substrate dependencies
-pallet-sudo = { workspace = true, features = ["std"] }
-substrate-test-client = { workspace = true }
-substrate-test-runtime-client = { workspace = true }
 
 [features]
 default = []
-# allow workers to register without remote attestation for dev purposes
 runtime-benchmarks = [
     "try-runtime-cli/try-runtime",
     "polkadot-service/runtime-benchmarks",
@@ -129,7 +125,6 @@ fast-runtime = [
     "polkadot-service/fast-runtime",
     "parachain-runtime/fast-runtime",
 ]
-
 try-runtime = [
     "try-runtime-cli/try-runtime",
     "parachain-runtime/try-runtime",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -105,7 +105,7 @@ substrate-build-script-utils = { workspace = true }
 assert_cmd = { workspace = true }
 nix = { workspace = true }
 pallet-sudo = { workspace = true, features = ["std"] }
-polkadot-cli = { workspace = true, features = ["rococo-native"]} # purge_chain_works works with rococo-local and needs to allow this
+polkadot-cli = { workspace = true, features = ["rococo-native"] } # purge_chain_works works with rococo-local and needs to allow this
 substrate-test-client = { workspace = true }
 substrate-test-runtime-client = { workspace = true }
 tempfile = { workspace = true }

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -15,13 +15,13 @@ path = "src/main.rs"
 
 [dependencies]
 async-trait = { workspace = true }
-clap = { workspace = true, features = ["std"] }
-codec = { workspace = true, features = ["std"] }
+clap = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["std"] }
 hex-literal = { workspace = true }
 log = { workspace = true, features = ["std"] }
-serde = { workspace = true, features = ["std"] }
-serde_json = { workspace = true, features = ["std"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Parachain runtimes
 parachain-runtime = { package = "integritee-runtime", path = "integritee-runtime" }

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -14,14 +14,14 @@ name = "integritee-collator"
 path = "src/main.rs"
 
 [dependencies]
-async-trait = "0.1.59"
-clap = { version = "4.0.29", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.1" }
-futures = "0.3.25"
-hex-literal = "0.3.4"
-log = "0.4.17"
-serde = { version = "1.0.171", features = ["derive"] }
-serde_json = "1.0.102"
+async-trait = { workspace = true }
+clap = { workspace = true, features = ["std"] }
+codec = { workspace = true, features = ["std"] }
+futures = { workspace = true, features = ["std"] }
+hex-literal = { workspace = true }
+log = { workspace = true, features = ["std"] }
+serde = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 
 # Parachain runtimes
 parachain-runtime = { package = "integritee-runtime", path = "integritee-runtime" }
@@ -29,91 +29,91 @@ parachains-common = { path = "common" }
 shell-runtime = { package = "shell-runtime", path = "shell-runtime" }
 
 # Substrate dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-consensus-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-network-common = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-network-sync = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-sysinfo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-benchmarking = { workspace = true, features = ["std"] }
+frame-benchmarking-cli = { workspace = true }
+sc-basic-authorship = { workspace = true }
+sc-chain-spec = { workspace = true }
+sc-cli = { workspace = true }
+sc-client-api = { workspace = true }
+sc-consensus = { workspace = true }
+sc-consensus-grandpa = { workspace = true }
+sc-executor = { workspace = true }
+sc-network = { workspace = true }
+sc-network-common = { workspace = true }
+sc-network-sync = { workspace = true }
+sc-offchain = { workspace = true }
+sc-rpc = { workspace = true }
+sc-service = { workspace = true }
+sc-sysinfo = { workspace = true }
+sc-telemetry = { workspace = true }
+sc-tracing = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sp-api = { workspace = true, features = ["std"] }
+sp-block-builder = { workspace = true, features = ["std"] }
+sp-blockchain = { workspace = true }
+sp-consensus = { workspace = true }
+sp-consensus-aura = { workspace = true, features = ["std"] }
+sp-core = { workspace = true, features = ["std"] }
+sp-inherents = { workspace = true, features = ["std"] }
+sp-io = { workspace = true, features = ["std"] }
+sp-keyring = { workspace = true }
+sp-keystore = { workspace = true, features = ["std"] }
+sp-offchain = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }
+sp-session = { workspace = true, features = ["std"] }
+sp-timestamp = { workspace = true, features = ["std"] }
+sp-transaction-pool = { workspace = true, features = ["std"] }
+substrate-prometheus-endpoint = { workspace = true }
+try-runtime-cli = { workspace = true }
 
 # RPC related dependencies
-frame-rpc-system = { package = "substrate-frame-rpc-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-jsonrpsee = { version = "0.16.2", features = ["server"] }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-substrate-state-trie-migration-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-rpc-system = { workspace = true }
+jsonrpsee = { workspace = true }
+pallet-transaction-payment-rpc = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+substrate-state-trie-migration-rpc = { workspace = true }
 
 # Cumulus dependencies
-color-print = "0.3.4"
-cumulus-client-cli = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-client-consensus-aura = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-client-consensus-relay-chain = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-client-network = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-client-service = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+color-print = { workspace = true }
+cumulus-client-cli = { workspace = true }
+cumulus-client-consensus-aura = { workspace = true }
+cumulus-client-consensus-common = { workspace = true }
+cumulus-client-consensus-relay-chain = { workspace = true }
+cumulus-client-network = { workspace = true }
+cumulus-client-service = { workspace = true }
+cumulus-primitives-core = { workspace = true, features = ["std"] }
+cumulus-primitives-parachain-inherent = { workspace = true, features = ["std"] }
+cumulus-relay-chain-inprocess-interface = { workspace = true }
+cumulus-relay-chain-interface = { workspace = true }
+cumulus-relay-chain-minimal-node = { workspace = true }
+cumulus-relay-chain-rpc-interface = { workspace = true }
 
 # Polkadot dependencies
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+polkadot-cli = { workspace = true }
+polkadot-primitives = { workspace = true, features = ["std"] }
+polkadot-service = { workspace = true }
+xcm = { workspace = true, features = ["std"] }
 
 # Temporary pin only
 # See https://github.com/bluejekyll/trust-dns/issues/1946 for more details.
-enum-as-inner = "=0.5.1"
+enum-as-inner = { workspace = true }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-build-script-utils = { workspace = true }
 
 [dev-dependencies]
-assert_cmd = "2.0"
-nix = "0.25"
-tempfile = "3.3.0"
-tokio = { version = "1.23.0", features = ["macros", "time", "parking_lot"] }
-wait-timeout = "0.2"
+assert_cmd = { workspace = true }
+nix = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+wait-timeout = { workspace = true }
 # purge_chain_works works with rococo-local and needs to allow this
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", features = ["rococo-native"], branch = "release-v1.0.0" }
+polkadot-cli = { workspace = true, features = ["rococo-native"]}
 
 # Substrate dependencies
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-sudo = { workspace = true, features = ["std"] }
+substrate-test-client = { workspace = true }
+substrate-test-runtime-client = { workspace = true }
 
 [features]
 default = []

--- a/polkadot-parachains/common/Cargo.toml
+++ b/polkadot-parachains/common/Cargo.toml
@@ -10,7 +10,7 @@ description = "Logic which is common to all parachain runtimes"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 smallvec = { workspace = true }
 
@@ -40,7 +40,7 @@ substrate-wasm-builder = { workspace = true }
 [features]
 default = ["std"]
 std = [
-    "codec/std",
+    "parity-scale-codec/std",
     "frame-executive/std",
     "frame-support/std",
     "frame-system/std",

--- a/polkadot-parachains/common/Cargo.toml
+++ b/polkadot-parachains/common/Cargo.toml
@@ -10,35 +10,32 @@ description = "Logic which is common to all parachain runtimes"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-# External dependencies
-codec = { package = "parity-scale-codec", version = "3.6.1", features = ["derive"], default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
-
-# dependencies not existing upstream
-smallvec = "1.9.0"
+codec = { workspace = true }
+scale-info = { workspace = true }
+smallvec = { workspace = true }
 
 # Substrate dependencies
-frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-assets = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-assets = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-balances = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Polkadot dependencies
-polkadot-core-primitives = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-polkadot-primitives = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-polkadot-runtime-common = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm-executor = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+polkadot-core-primitives = { workspace = true }
+polkadot-primitives = { workspace = true }
+polkadot-runtime-common = { workspace = true }
+xcm = { workspace = true }
+xcm-executor = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = ["std"]

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/integritee-network/parachain"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 
 parachains-common = { path = "../common", default-features = false }

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -9,13 +9,57 @@ repository = "https://github.com/integritee-network/parachain"
 edition = "2021"
 
 [dependencies]
-codec = { workspace = true }
+parity-scale-codec = { workspace = true }
 log = { workspace = true }
 scale-info = { workspace = true }
 
 parachains-common = { path = "../common", default-features = false }
 
 # Substrate dependencies
+
+# pallets
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-timestamp = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { workspace = true, optional = true }
+orml-traits = { workspace = true }
+orml-xcm = { workspace = true }
+orml-xcm-support = { workspace = true }
+orml-xtokens = { workspace = true }
+pallet-aura = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-bounties = { workspace = true }
+pallet-child-bounties = { workspace = true }
+pallet-claims = { workspace = true }
+pallet-collective = { workspace = true }
+pallet-democracy = { workspace = true }
+pallet-enclave-bridge = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-sidechain = { workspace = true }
+pallet-teeracle = { workspace = true }
+pallet-teerex = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-utility = { workspace = true }
+pallet-vesting = { workspace = true }
+pallet-xcm = { workspace = true }
+pallet-xcm-transactor = { workspace = true }
+parachain-info = { workspace = true }
+polkadot-parachain = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
@@ -28,65 +72,10 @@ sp-session = { workspace = true }
 sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
-
-frame-executive = { workspace = true }
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-frame-system-rpc-runtime-api = { workspace = true }
-frame-try-runtime = { workspace = true, optional = true }
-
-# pallets
-pallet-aura = { workspace = true }
-pallet-balances = { workspace = true }
-pallet-bounties = { workspace = true }
-pallet-child-bounties = { workspace = true }
-pallet-collective = { workspace = true }
-pallet-democracy = { workspace = true }
-pallet-multisig = { workspace = true }
-pallet-preimage = { workspace = true }
-pallet-proxy = { workspace = true }
-pallet-scheduler = { workspace = true }
-pallet-timestamp = { workspace = true }
-pallet-transaction-payment = { workspace = true }
-pallet-transaction-payment-rpc-runtime-api = { workspace = true }
-pallet-treasury = { workspace = true }
-pallet-utility = { workspace = true }
-pallet-vesting = { workspace = true }
-
-# integritee pallets
-pallet-claims = { workspace = true }
-pallet-enclave-bridge = { workspace = true }
-pallet-sidechain = { workspace = true }
-pallet-teeracle = { workspace = true }
-pallet-teerex = { workspace = true }
-pallet-xcm-transactor = { workspace = true }
-
-# other integritee deps
-xcm-transactor-primitives = { workspace = true }
-
-# Cumulus dependencies
-cumulus-pallet-aura-ext = { workspace = true }
-cumulus-pallet-dmp-queue = { workspace = true }
-cumulus-pallet-parachain-system = { workspace = true }
-cumulus-pallet-xcm = { workspace = true }
-cumulus-pallet-xcmp-queue = { workspace = true }
-cumulus-primitives-core = { workspace = true }
-cumulus-primitives-timestamp = { workspace = true }
-cumulus-primitives-utility = { workspace = true }
-parachain-info = { workspace = true }
-
-# Polkadot dependencies
-pallet-xcm = { workspace = true }
-polkadot-parachain = { workspace = true }
 xcm = { workspace = true }
 xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
-
-# orml
-orml-traits = { workspace = true }
-orml-xcm = { workspace = true }
-orml-xcm-support = { workspace = true }
-orml-xtokens = { workspace = true }
+xcm-transactor-primitives = { workspace = true }
 
 # Benchmarking
 frame-benchmarking = { workspace = true, optional = true }
@@ -94,12 +83,11 @@ frame-system-benchmarking = { workspace = true, optional = true }
 hex-literal = { workspace = true, optional = true }
 
 [dev-dependencies]
-hex-literal = { workspace = true }
-hex = { workspace = true }
 cumulus-primitives-parachain-inherent = { workspace = true, features = ["std"] }
+hex = { workspace = true }
+hex-literal = { workspace = true }
 polkadot-primitives = { workspace = true, features = ["std"] }
 polkadot-runtime-parachains = { workspace = true, features = ["std"] }
-
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true }
@@ -107,7 +95,6 @@ substrate-wasm-builder = { workspace = true }
 [features]
 default = ["std"]
 std = [
-    "codec/std",
     "cumulus-pallet-aura-ext/std",
     "cumulus-pallet-dmp-queue/std",
     "cumulus-pallet-parachain-system/std",
@@ -151,6 +138,7 @@ std = [
     "pallet-xcm/std",
     "parachain-info/std",
     "parachains-common/std",
+    "parity-scale-codec/std",
     "polkadot-parachain/std",
     "scale-info/std",
     "sp-api/std",
@@ -171,17 +159,13 @@ std = [
     "xcm/std",
 ]
 runtime-benchmarks = [
-    # support stuff
+    "cumulus-pallet-xcmp-queue/runtime-benchmarks",
     "frame-benchmarking/runtime-benchmarks",
     "frame-support/runtime-benchmarks",
     "frame-system-benchmarking/runtime-benchmarks",
     "frame-system/runtime-benchmarks",
-    "hex-literal",
-    "sp-runtime/runtime-benchmarks",
-    "pallet-xcm/runtime-benchmarks",
-    "xcm-builder/runtime-benchmarks",
-    # actual pallets to be benchmarked
     "frame-system/runtime-benchmarks",
+    "hex-literal",
     "pallet-balances/runtime-benchmarks",
     "pallet-bounties/runtime-benchmarks",
     "pallet-child-bounties/runtime-benchmarks",
@@ -190,31 +174,32 @@ runtime-benchmarks = [
     "pallet-democracy/runtime-benchmarks",
     "pallet-enclave-bridge/runtime-benchmarks",
     "pallet-multisig/runtime-benchmarks",
-    "pallet-proxy/runtime-benchmarks",
     "pallet-preimage/runtime-benchmarks",
+    "pallet-proxy/runtime-benchmarks",
     "pallet-scheduler/runtime-benchmarks",
     "pallet-sidechain/runtime-benchmarks",
     "pallet-teeracle/runtime-benchmarks",
     "pallet-teerex/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-treasury/runtime-benchmarks",
-    "pallet-vesting/runtime-benchmarks",
     "pallet-utility/runtime-benchmarks",
-    "cumulus-pallet-xcmp-queue/runtime-benchmarks",
+    "pallet-vesting/runtime-benchmarks",
+    "pallet-xcm/runtime-benchmarks",
+    "sp-runtime/runtime-benchmarks",
+    "xcm-builder/runtime-benchmarks",
 ]
 
 try-runtime = [
-    "frame-try-runtime/try-runtime",
-    "frame-system/try-runtime",
-    "frame-executive/try-runtime",
-    "cumulus-pallet-parachain-system/try-runtime",
     "cumulus-pallet-aura-ext/try-runtime",
-    "cumulus-pallet-xcmp-queue/try-runtime",
-    "cumulus-pallet-xcm/try-runtime",
     "cumulus-pallet-dmp-queue/try-runtime",
-    "orml-xtokens/try-runtime",
+    "cumulus-pallet-parachain-system/try-runtime",
+    "cumulus-pallet-xcm/try-runtime",
+    "cumulus-pallet-xcmp-queue/try-runtime",
+    "frame-executive/try-runtime",
+    "frame-system/try-runtime",
+    "frame-try-runtime/try-runtime",
     "orml-xcm/try-runtime",
-    "parachain-info/try-runtime",
+    "orml-xtokens/try-runtime",
     "pallet-aura/try-runtime",
     "pallet-balances/try-runtime",
     "pallet-bounties/try-runtime",
@@ -224,8 +209,8 @@ try-runtime = [
     "pallet-democracy/try-runtime",
     "pallet-enclave-bridge/try-runtime",
     "pallet-multisig/try-runtime",
-    "pallet-proxy/try-runtime",
     "pallet-preimage/try-runtime",
+    "pallet-proxy/try-runtime",
     "pallet-scheduler/try-runtime",
     "pallet-sidechain/try-runtime",
     "pallet-teeracle/try-runtime",
@@ -233,10 +218,11 @@ try-runtime = [
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
     "pallet-treasury/try-runtime",
-    "pallet-vesting/try-runtime",
     "pallet-utility/try-runtime",
-    "pallet-xcm/try-runtime",
+    "pallet-vesting/try-runtime",
     "pallet-xcm-transactor/try-runtime",
+    "pallet-xcm/try-runtime",
+    "parachain-info/try-runtime",
 ]
 # Set timing constants (e.g. session period) to faster versions to speed up testing.
 fast-runtime = []

--- a/polkadot-parachains/integritee-runtime/Cargo.toml
+++ b/polkadot-parachains/integritee-runtime/Cargo.toml
@@ -9,100 +9,100 @@ repository = "https://github.com/integritee-network/parachain"
 edition = "2021"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
 
 parachains-common = { path = "../common", default-features = false }
 
 # Substrate dependencies
-sp-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-inherents = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-offchain = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-transaction-pool = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-version = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-io = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
-frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v1.0.0", optional = true }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { workspace = true, optional = true }
 
 # pallets
-pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-bounties = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-child-bounties = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-collective = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-democracy = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-multisig = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-preimage = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-proxy = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-scheduler = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-treasury = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-utility = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v1.0.0" }
-pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-aura = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-bounties = { workspace = true }
+pallet-child-bounties = { workspace = true }
+pallet-collective = { workspace = true }
+pallet-democracy = { workspace = true }
+pallet-multisig = { workspace = true }
+pallet-preimage = { workspace = true }
+pallet-proxy = { workspace = true }
+pallet-scheduler = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-treasury = { workspace = true }
+pallet-utility = { workspace = true }
+pallet-vesting = { workspace = true }
 
 # integritee pallets
-pallet-claims = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
-pallet-enclave-bridge = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
-pallet-sidechain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
-pallet-teeracle = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
-pallet-teerex = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
-pallet-xcm-transactor = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+pallet-claims = { workspace = true }
+pallet-enclave-bridge = { workspace = true }
+pallet-sidechain = { workspace = true }
+pallet-teeracle = { workspace = true }
+pallet-teerex = { workspace = true }
+pallet-xcm-transactor = { workspace = true }
 
 # other integritee deps
-xcm-transactor-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+xcm-transactor-primitives = { workspace = true }
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-dmp-queue = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-parachain-system = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-xcm = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-xcmp-queue = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-timestamp = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-utility = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-parachain-info = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-timestamp = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+parachain-info = { workspace = true }
 
 # Polkadot dependencies
-pallet-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-polkadot-parachain = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm-builder = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm-executor = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+pallet-xcm = { workspace = true }
+polkadot-parachain = { workspace = true }
+xcm = { workspace = true }
+xcm-builder = { workspace = true }
+xcm-executor = { workspace = true }
 
 # orml
-orml-traits = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
-orml-xcm = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
-orml-xcm-support = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
-orml-xtokens = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
+orml-traits = { workspace = true }
+orml-xcm = { workspace = true }
+orml-xcm-support = { workspace = true }
+orml-xtokens = { workspace = true }
 
 # Benchmarking
-frame-benchmarking = { optional = true, default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system-benchmarking = { optional = true, default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-hex-literal = { version = "0.3.4", optional = true }
+frame-benchmarking = { workspace = true, optional = true }
+frame-system-benchmarking = { workspace = true, optional = true }
+hex-literal = { workspace = true, optional = true }
 
 [dev-dependencies]
-hex-literal = "0.3.4"
-hex = "0.4.3"
-cumulus-primitives-parachain-inherent = { git = 'https://github.com/paritytech/cumulus', branch = "polkadot-v1.0.0" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+hex-literal = { workspace = true }
+hex = { workspace = true }
+cumulus-primitives-parachain-inherent = { workspace = true, features = ["std"] }
+polkadot-primitives = { workspace = true, features = ["std"] }
+polkadot-runtime-parachains = { workspace = true, features = ["std"] }
 
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = ["std"]

--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -23,7 +23,6 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use frame_support::traits::{
 	ConstBool, EqualPrivilegeOnly, Imbalance, InstanceFilter, OnUnbalanced,
@@ -31,6 +30,7 @@ use frame_support::traits::{
 pub use opaque::*;
 use pallet_collective;
 use pallet_transaction_payment::{FeeDetails, RuntimeDispatchInfo};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, ConstU32, OpaqueMetadata};
 use sp_runtime::{

--- a/polkadot-parachains/integritee-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/integritee-runtime/src/xcm_config.rs
@@ -24,7 +24,6 @@ use super::{
 	XcmpQueue, TEER,
 };
 use crate::weights;
-use codec::{Decode, Encode, MaxEncodedLen};
 use core::marker::PhantomData;
 use cumulus_primitives_core::GlobalConsensus;
 use frame_support::{
@@ -41,6 +40,7 @@ use orml_traits::{
 };
 use orml_xcm_support::{IsNativeConcrete, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_parachain::primitives::Sibling;
 use scale_info::TypeInfo;
 use sp_core::ConstU32;

--- a/polkadot-parachains/shell-runtime/Cargo.toml
+++ b/polkadot-parachains/shell-runtime/Cargo.toml
@@ -9,19 +9,40 @@ repository = "https://github.com/integritee-network/parachain"
 edition = "2021"
 
 [dependencies]
-codec = { workspace = true }
+parity-scale-codec = { workspace = true }
 log = { workspace = true }
 scale-info = { workspace = true }
 
 parachains-common = { path = "../common", default-features = false }
 
 # Substrate dependencies
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-timestamp = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
 frame-executive = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 frame-system-rpc-runtime-api = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
+orml-traits = { workspace = true }
+orml-xcm = { workspace = true }
+orml-xcm-support = { workspace = true }
+pallet-aura = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-sudo = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
 pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+pallet-vesting = { workspace = true }
+pallet-xcm = { workspace = true }
+pallet-xcm-transactor = { workspace = true }
+parachain-info = { workspace = true }
+polkadot-parachain = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
@@ -34,41 +55,10 @@ sp-session = { workspace = true }
 sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
-
-# added by integritee
-pallet-aura = { workspace = true }
-pallet-balances = { workspace = true }
-pallet-sudo = { workspace = true }
-pallet-timestamp = { workspace = true }
-pallet-transaction-payment = { workspace = true }
-pallet-vesting = { workspace = true }
-
-# Cumulus dependencies
-cumulus-pallet-aura-ext = { workspace = true }
-cumulus-pallet-dmp-queue = { workspace = true }
-cumulus-pallet-parachain-system = { workspace = true }
-cumulus-pallet-xcm = { workspace = true }
-cumulus-pallet-xcmp-queue = { workspace = true }
-cumulus-primitives-core = { workspace = true }
-cumulus-primitives-timestamp = { workspace = true }
-cumulus-primitives-utility = { workspace = true }
-parachain-info = { workspace = true }
-
-# Polkadot dependencies
-pallet-xcm = { workspace = true }
-pallet-xcm-transactor = { workspace = true }
-polkadot-parachain = { workspace = true }
 xcm = { workspace = true }
 xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
-
-# other integritee deps
 xcm-transactor-primitives = { workspace = true }
-
-# orml
-orml-traits = { workspace = true }
-orml-xcm = { workspace = true }
-orml-xcm-support = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }
@@ -80,50 +70,52 @@ substrate-wasm-builder = { workspace = true }
 [features]
 default = ["std"]
 std = [
-    "codec/std",
-    "scale-info/std",
-    "log/std",
-    "parachains-common/std",
-    "sp-api/std",
-    "sp-std/std",
-    "sp-io/std",
-    "sp-core/std",
-    "sp-runtime/std",
-    "sp-version/std",
-    "sp-offchain/std",
-    "sp-session/std",
-    "sp-block-builder/std",
-    "sp-transaction-pool/std",
-    "sp-inherents/std",
-    "frame-support/std",
-    "frame-executive/std",
-    "frame-system/std",
-    "frame-system-rpc-runtime-api/std",
-    "parachain-info/std",
-    "orml-traits/std",
-    "orml-xcm/std",
-    "orml-xcm-support/std",
-    "cumulus-pallet-parachain-system/std",
+    "cumulus-pallet-aura-ext/std",
     "cumulus-pallet-dmp-queue/std",
+    "cumulus-pallet-parachain-system/std",
     "cumulus-pallet-xcm/std",
     "cumulus-pallet-xcmp-queue/std",
     "cumulus-primitives-core/std",
+    "cumulus-primitives-timestamp/std",
     "cumulus-primitives-utility/std",
-    "xcm/std",
-    "xcm-builder/std",
-    "xcm-executor/std",
-    "xcm-transactor-primitives/std",
+    "frame-executive/std",
+    "frame-support/std",
+    "frame-system-rpc-runtime-api/std",
+    "frame-system/std",
+    "log/std",
+    "orml-traits/std",
+    "orml-xcm-support/std",
+    "orml-xcm/std",
+    "pallet-aura/std",
     "pallet-balances/std",
     "pallet-sudo/std",
     "pallet-timestamp/std",
-    "pallet-aura/std",
-    "pallet-transaction-payment/std",
     "pallet-transaction-payment-rpc-runtime-api/std",
+    "pallet-transaction-payment/std",
     "pallet-vesting/std",
     "pallet-xcm-transactor/std",
     "pallet-xcm/std",
-    "cumulus-pallet-aura-ext/std",
+    "parachain-info/std",
+    "parachains-common/std",
+    "parity-scale-codec/std",
+    "polkadot-parachain/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-block-builder/std",
     "sp-consensus-aura/std",
+    "sp-core/std",
+    "sp-inherents/std",
+    "sp-io/std",
+    "sp-offchain/std",
+    "sp-runtime/std",
+    "sp-session/std",
+    "sp-std/std",
+    "sp-transaction-pool/std",
+    "sp-version/std",
+    "xcm-builder/std",
+    "xcm-executor/std",
+    "xcm-transactor-primitives/std",
+    "xcm/std",
 ]
 # Weird cargo behaviour: We have to feature gate the `runtime-benchmarks` behind
 # a feature here. Otherwise the feature is automatically activated in dependencies
@@ -136,21 +128,21 @@ runtime-benchmarks = [
 ]
 
 try-runtime = [
-    "frame-try-runtime/try-runtime",
-    "frame-system/try-runtime",
-    "frame-executive/try-runtime",
-    "cumulus-pallet-parachain-system/try-runtime",
     "cumulus-pallet-aura-ext/try-runtime",
-    "cumulus-pallet-xcmp-queue/try-runtime",
-    "cumulus-pallet-xcm/try-runtime",
     "cumulus-pallet-dmp-queue/try-runtime",
+    "cumulus-pallet-parachain-system/try-runtime",
+    "cumulus-pallet-xcm/try-runtime",
+    "cumulus-pallet-xcmp-queue/try-runtime",
+    "frame-executive/try-runtime",
+    "frame-system/try-runtime",
+    "frame-try-runtime/try-runtime",
     "orml-xcm/try-runtime",
-    "parachain-info/try-runtime",
     "pallet-aura/try-runtime",
     "pallet-balances/try-runtime",
     "pallet-timestamp/try-runtime",
     "pallet-transaction-payment/try-runtime",
     "pallet-vesting/try-runtime",
-    "pallet-xcm/try-runtime",
     "pallet-xcm-transactor/try-runtime",
+    "pallet-xcm/try-runtime",
+    "parachain-info/try-runtime",
 ]

--- a/polkadot-parachains/shell-runtime/Cargo.toml
+++ b/polkadot-parachains/shell-runtime/Cargo.toml
@@ -9,73 +9,73 @@ repository = "https://github.com/integritee-network/parachain"
 edition = "2021"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.1", default-features = false, features = ["derive"] }
-log = { version = "0.4.17", default-features = false }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { workspace = true }
+log = { workspace = true }
+scale-info = { workspace = true }
 
 parachains-common = { path = "../common", default-features = false }
 
 # Substrate dependencies
-frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-frame-try-runtime = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "polkadot-v1.0.0", optional = true }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-block-builder = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-inherents = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-offchain = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-transaction-pool = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-sp-version = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+frame-executive = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+frame-system-rpc-runtime-api = { workspace = true }
+frame-try-runtime = { workspace = true, optional = true }
+pallet-transaction-payment-rpc-runtime-api = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-inherents = { workspace = true }
+sp-io = { workspace = true }
+sp-offchain = { workspace = true }
+sp-runtime = { workspace = true }
+sp-session = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
+sp-version = { workspace = true }
 
 # added by integritee
-pallet-aura = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
-pallet-vesting = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+pallet-aura = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-sudo = { workspace = true }
+pallet-timestamp = { workspace = true }
+pallet-transaction-payment = { workspace = true }
+pallet-vesting = { workspace = true }
 
 # Cumulus dependencies
-cumulus-pallet-aura-ext = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-dmp-queue = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-parachain-system = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-xcm = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-pallet-xcmp-queue = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-core = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-timestamp = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-cumulus-primitives-utility = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
-parachain-info = { default-features = false, git = "https://github.com/paritytech/cumulus", branch = "polkadot-v1.0.0" }
+cumulus-pallet-aura-ext = { workspace = true }
+cumulus-pallet-dmp-queue = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true }
+cumulus-pallet-xcm = { workspace = true }
+cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-core = { workspace = true }
+cumulus-primitives-timestamp = { workspace = true }
+cumulus-primitives-utility = { workspace = true }
+parachain-info = { workspace = true }
 
 # Polkadot dependencies
-pallet-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-pallet-xcm-transactor = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
-polkadot-parachain = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm-builder = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
-xcm-executor = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "release-v1.0.0" }
+pallet-xcm = { workspace = true }
+pallet-xcm-transactor = { workspace = true }
+polkadot-parachain = { workspace = true }
+xcm = { workspace = true }
+xcm-builder = { workspace = true }
+xcm-executor = { workspace = true }
 
 # other integritee deps
-xcm-transactor-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v1.0.0" }
+xcm-transactor-primitives = { workspace = true }
 
 # orml
-orml-traits = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
-orml-xcm = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
-orml-xcm-support = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library.git", branch = "polkadot-v1.0.0" }
+orml-traits = { workspace = true }
+orml-xcm = { workspace = true }
+orml-xcm-support = { workspace = true }
 
 [dev-dependencies]
-hex = "0.4.3"
-hex-literal = "0.3.4"
+hex = { workspace = true }
+hex-literal = { workspace = true }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v1.0.0" }
+substrate-wasm-builder = { workspace = true }
 
 [features]
 default = ["std"]

--- a/polkadot-parachains/shell-runtime/Cargo.toml
+++ b/polkadot-parachains/shell-runtime/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/integritee-network/parachain"
 edition = "2021"
 
 [dependencies]
-parity-scale-codec = { workspace = true }
 log = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 
 parachains-common = { path = "../common", default-features = false }

--- a/polkadot-parachains/shell-runtime/src/xcm_config.rs
+++ b/polkadot-parachains/shell-runtime/src/xcm_config.rs
@@ -22,7 +22,6 @@ use super::{
 	AccountId, Balance, Balances, Convert, MaxInstructions, ParachainInfo, ParachainSystem,
 	PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, XcmpQueue, TEER,
 };
-use codec::{Decode, Encode, MaxEncodedLen};
 use core::marker::PhantomData;
 use cumulus_primitives_core::GlobalConsensus;
 use frame_support::{
@@ -39,6 +38,7 @@ use orml_traits::{
 };
 use orml_xcm_support::{IsNativeConcrete, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use polkadot_parachain::primitives::Sibling;
 use scale_info::TypeInfo;
 use sp_core::ConstU32;

--- a/polkadot-parachains/src/command.rs
+++ b/polkadot-parachains/src/command.rs
@@ -27,12 +27,12 @@ use crate::{
 		new_partial, Block, IntegriteeParachainRuntimeExecutor, ShellParachainRuntimeExecutor,
 	},
 };
-use codec::Encode;
 use cumulus_client_cli::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use log::{info, warn};
 use parachains_common::AuraId;
+use parity_scale_codec::Encode;
 use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
 	NetworkParams, Result, SharedParams, SubstrateCli,

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Integritee parachain.  If not, see <http://www.gnu.org/licenses/>.
 
-use codec::Codec;
 use cumulus_client_cli::CollatorOptions;
 use cumulus_client_consensus_aura::{AuraConsensus, BuildAuraConsensusParams, SlotProportion};
 use cumulus_client_consensus_common::{
@@ -30,6 +29,7 @@ use cumulus_primitives_core::{
 	ParaId,
 };
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface};
+use parity_scale_codec::Codec;
 use sp_core::Pair;
 
 use jsonrpsee::RpcModule;


### PR DESCRIPTION
before migrating to polkadot 1.3.0 and crates.io, move all dependency definitions to workspace toml to remove redundancy and simplify future upgrades

functionally, this PR is a noop

see also https://github.com/integritee-network/pallets/pull/247