### PR TITLE
add state migration to purge scheduler agenda

### DIFF
--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -26,44 +26,44 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use cumulus_primitives_core::AggregateMessageOrigin;
 pub use frame_support::{
-	construct_runtime,
-	dispatch::DispatchClass,
-	pallet_prelude::Get,
-	parameter_types,
-	traits::{
-		EitherOfDiverse, Everything, IsInVec, Nothing, PalletInfoAccess, Randomness,
-		WithdrawReasons,
-	},
-	weights::{
-		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
-		IdentityFee, Weight,
-	},
-	PalletId, StorageValue,
+    construct_runtime,
+    dispatch::DispatchClass,
+    pallet_prelude::Get,
+    parameter_types,
+    traits::{
+        EitherOfDiverse, Everything, IsInVec, Nothing, PalletInfoAccess, Randomness,
+        WithdrawReasons,
+    },
+    weights::{
+        constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
+        IdentityFee, Weight,
+    },
+    PalletId, StorageValue,
 };
 use frame_support::{
-	derive_impl,
-	genesis_builder_helper::{build_config, create_default_config},
-	ord_parameter_types,
-	traits::{
-		fungible::{HoldConsideration, NativeFromLeft, NativeOrWithId, UnionOf},
-		tokens::{imbalance::ResolveAssetTo, ConversionFromAssetBalance, PayFromAccount},
-		AsEnsureOriginWithArg, ConstBool, EnsureOriginWithArg, EqualPrivilegeOnly, Imbalance,
-		InstanceFilter, LinearStoragePrice, OnUnbalanced,
-	},
-	weights::ConstantMultiplier,
+    derive_impl,
+    genesis_builder_helper::{build_config, create_default_config},
+    ord_parameter_types,
+    traits::{
+        fungible::{HoldConsideration, NativeFromLeft, NativeOrWithId, UnionOf},
+        tokens::{imbalance::ResolveAssetTo, ConversionFromAssetBalance, PayFromAccount},
+        AsEnsureOriginWithArg, ConstBool, EnsureOriginWithArg, EqualPrivilegeOnly, Imbalance,
+        InstanceFilter, LinearStoragePrice, OnUnbalanced,
+    },
+    weights::ConstantMultiplier,
 };
 use frame_system::{
-	limits::{BlockLength, BlockWeights},
-	EnsureRoot, EnsureSignedBy, EnsureWithSuccess,
+    limits::{BlockLength, BlockWeights},
+    EnsureRoot, EnsureSignedBy, EnsureWithSuccess,
 };
 use integritee_parachains_common::{
-	fee::{SlowAdjustingFeeUpdate, WeightToFee},
-	AuraId, AVERAGE_ON_INITIALIZE_RATIO, BLOCK_PROCESSING_VELOCITY, DAYS, HOURS,
-	MAXIMUM_BLOCK_WEIGHT, MINUTES, NORMAL_DISPATCH_RATIO, RELAY_CHAIN_SLOT_DURATION_MILLIS,
-	SLOT_DURATION, UNINCLUDED_SEGMENT_CAPACITY,
+    fee::{SlowAdjustingFeeUpdate, WeightToFee},
+    AuraId, AVERAGE_ON_INITIALIZE_RATIO, BLOCK_PROCESSING_VELOCITY, DAYS, HOURS,
+    MAXIMUM_BLOCK_WEIGHT, MINUTES, NORMAL_DISPATCH_RATIO, RELAY_CHAIN_SLOT_DURATION_MILLIS,
+    SLOT_DURATION, UNINCLUDED_SEGMENT_CAPACITY,
 };
 pub use integritee_parachains_common::{
-	AccountId, Address, Balance, BlockNumber, Hash, Header, Nonce, Signature, MILLISECS_PER_BLOCK,
+    AccountId, Address, Balance, BlockNumber, Hash, Header, Nonce, Signature, MILLISECS_PER_BLOCK,
 };
 use pallet_asset_conversion::{Ascending, Chain, WithFirstAsset};
 pub use pallet_balances::Call as BalancesCall;
@@ -82,10 +82,10 @@ use sp_core::{crypto::KeyTypeId, ConstU128, ConstU32, OpaqueMetadata};
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{
-	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, ConvertInto, IdentityLookup},
-	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, RuntimeDebug,
+    create_runtime_str, generic, impl_opaque_keys,
+    traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, ConvertInto, IdentityLookup},
+    transaction_validity::{TransactionSource, TransactionValidity},
+    ApplyExtrinsicResult, RuntimeDebug,
 };
 pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
@@ -97,6 +97,7 @@ mod helpers;
 mod weights;
 
 pub mod xcm_config;
+mod migrations;
 
 pub type SessionHandlers = ();
 
@@ -105,7 +106,7 @@ pub type SessionHandlers = ();
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
 /// to even the core data structures.
 pub mod opaque {
-	pub use integritee_parachains_common::opaque::*;
+    pub use integritee_parachains_common::opaque::*;
 }
 
 impl_opaque_keys! {
@@ -116,14 +117,14 @@ impl_opaque_keys! {
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("integritee-parachain"),
-	impl_name: create_runtime_str!("integritee-full"),
-	authoring_version: 2,
-	spec_version: 51,
-	impl_version: 1,
-	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 7,
-	state_version: 0,
+    spec_name: create_runtime_str!("integritee-parachain"),
+    impl_name: create_runtime_str!("integritee-full"),
+    authoring_version: 2,
+    spec_version: 51,
+    impl_version: 1,
+    apis: RUNTIME_API_VERSIONS,
+    transaction_version: 7,
+    state_version: 0,
 };
 
 pub const TEER: Balance = 1_000_000_000_000;
@@ -132,7 +133,7 @@ pub const MICROTEER: Balance = 1_000_000;
 
 // Logic from Polkadot/Kusama.
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-	items as Balance * 20 * TEER + (bytes as Balance) * 1_000 * MICROTEER
+    items as Balance * 20 * TEER + (bytes as Balance) * 1_000 * MICROTEER
 }
 
 /// A timestamp: milliseconds since the unix epoch.
@@ -141,28 +142,28 @@ pub type Moment = u64;
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+    NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 pub struct DealWithFees;
 
 impl OnUnbalanced<pallet_balances::NegativeImbalance<Runtime>> for DealWithFees {
-	fn on_unbalanceds<B>(
-		mut fees_then_tips: impl Iterator<Item = pallet_balances::NegativeImbalance<Runtime>>,
-	) {
-		if let Some(fees) = fees_then_tips.next() {
-			// for fees, 1% to treasury, 99% burned
-			// TODO: apply burning function based on cumulative number of extrinsics (#32)
-			let mut split = fees.ration(1, 99);
+    fn on_unbalanceds<B>(
+        mut fees_then_tips: impl Iterator<Item=pallet_balances::NegativeImbalance<Runtime>>,
+    ) {
+        if let Some(fees) = fees_then_tips.next() {
+            // for fees, 1% to treasury, 99% burned
+            // TODO: apply burning function based on cumulative number of extrinsics (#32)
+            let mut split = fees.ration(1, 99);
 
-			// tips (voluntary extra fees) go to the treasury entirely. no burning
-			if let Some(tips) = fees_then_tips.next() {
-				tips.merge_into(&mut split.0);
-			}
-			Treasury::on_unbalanced(split.0);
-			// burn remainder by not assigning imbalance to someone
-		}
-	}
+            // tips (voluntary extra fees) go to the treasury entirely. no burning
+            if let Some(tips) = fees_then_tips.next() {
+                tips.merge_into(&mut split.0);
+            }
+            Treasury::on_unbalanced(split.0);
+            // burn remainder by not assigning imbalance to someone
+        }
+    }
 }
 
 parameter_types! {
@@ -196,21 +197,21 @@ parameter_types! {
 /// but overridden as needed.
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-	type BaseCallFilter = Everything;
-	type BlockWeights = RuntimeBlockWeights;
-	type BlockLength = RuntimeBlockLength;
-	type Block = Block;
-	type AccountId = AccountId;
-	type Nonce = Nonce;
-	type Hash = Hash;
-	type BlockHashCount = BlockHashCount;
-	type DbWeight = RocksDbWeight;
-	type Version = Version;
-	type AccountData = pallet_balances::AccountData<Balance>;
-	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
-	type SS58Prefix = SS58Prefix;
-	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+    type BaseCallFilter = Everything;
+    type BlockWeights = RuntimeBlockWeights;
+    type BlockLength = RuntimeBlockLength;
+    type Block = Block;
+    type AccountId = AccountId;
+    type Nonce = Nonce;
+    type Hash = Hash;
+    type BlockHashCount = BlockHashCount;
+    type DbWeight = RocksDbWeight;
+    type Version = Version;
+    type AccountData = pallet_balances::AccountData<Balance>;
+    type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
+    type SS58Prefix = SS58Prefix;
+    type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {
@@ -218,11 +219,11 @@ parameter_types! {
 }
 
 impl pallet_timestamp::Config for Runtime {
-	/// A timestamp: milliseconds since the unix epoch.
-	type Moment = Moment;
-	type OnTimestampSet = ();
-	type MinimumPeriod = MinimumPeriod;
-	type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
+    /// A timestamp: milliseconds since the unix epoch.
+    type Moment = Moment;
+    type OnTimestampSet = ();
+    type MinimumPeriod = MinimumPeriod;
+    type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -236,30 +237,30 @@ parameter_types! {
 }
 
 impl pallet_balances::Config for Runtime {
-	type MaxLocks = MaxLocks;
-	/// The type for recording an account's balance.
-	type Balance = Balance;
-	/// The ubiquitous event type.
-	type RuntimeEvent = RuntimeEvent;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = System;
-	type WeightInfo = weights::pallet_balances::WeightInfo<Runtime>;
-	type MaxReserves = MaxReserves;
-	type ReserveIdentifier = [u8; 8];
-	type RuntimeHoldReason = RuntimeHoldReason;
-	type RuntimeFreezeReason = ();
-	type FreezeIdentifier = ();
-	type MaxFreezes = ();
+    type MaxLocks = MaxLocks;
+    /// The type for recording an account's balance.
+    type Balance = Balance;
+    /// The ubiquitous event type.
+    type RuntimeEvent = RuntimeEvent;
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = System;
+    type WeightInfo = weights::pallet_balances::WeightInfo<Runtime>;
+    type MaxReserves = MaxReserves;
+    type ReserveIdentifier = [u8; 8];
+    type RuntimeHoldReason = RuntimeHoldReason;
+    type RuntimeFreezeReason = ();
+    type FreezeIdentifier = ();
+    type MaxFreezes = ();
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees>;
-	type WeightToFee = WeightToFee;
-	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
-	type OperationalFeeMultiplier = OperationalFeeMultiplier;
+    type RuntimeEvent = RuntimeEvent;
+    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees>;
+    type WeightToFee = WeightToFee;
+    type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
+    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
+    type OperationalFeeMultiplier = OperationalFeeMultiplier;
 }
 
 parameter_types! {
@@ -271,13 +272,13 @@ parameter_types! {
 }
 
 impl pallet_multisig::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
-	type Currency = Balances;
-	type DepositBase = DepositBase;
-	type DepositFactor = DepositFactor;
-	type MaxSignatories = MaxSignatories;
-	type WeightInfo = weights::pallet_multisig::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type Currency = Balances;
+    type DepositBase = DepositBase;
+    type DepositFactor = DepositFactor;
+    type MaxSignatories = MaxSignatories;
+    type WeightInfo = weights::pallet_multisig::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -293,39 +294,39 @@ parameter_types! {
 
 /// The type used to represent the kinds of proxying allowed.
 #[derive(
-	Copy,
-	Clone,
-	Eq,
-	PartialEq,
-	Ord,
-	PartialOrd,
-	Encode,
-	Decode,
-	RuntimeDebug,
-	MaxEncodedLen,
-	TypeInfo,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Encode,
+    Decode,
+    RuntimeDebug,
+    MaxEncodedLen,
+    TypeInfo,
 )]
 pub enum ProxyType {
-	Any,         // Any transactions.
-	NonTransfer, // Any type of transaction except balance transfers (including vested transfers)
-	Governance,
-	// Staking = 3,
-	// IdentityJudgement = 4,
-	CancelProxy,
-	// Auction,
+    Any,         // Any transactions.
+    NonTransfer, // Any type of transaction except balance transfers (including vested transfers)
+    Governance,
+    // Staking = 3,
+    // IdentityJudgement = 4,
+    CancelProxy,
+    // Auction,
 }
 
 impl Default for ProxyType {
-	fn default() -> Self {
-		Self::Any
-	}
+    fn default() -> Self {
+        Self::Any
+    }
 }
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
-	fn filter(&self, c: &RuntimeCall) -> bool {
-		match self {
-			ProxyType::Any => true,
-			ProxyType::NonTransfer => matches!(
+    fn filter(&self, c: &RuntimeCall) -> bool {
+        match self {
+            ProxyType::Any => true,
+            ProxyType::NonTransfer => matches!(
 				c,
 				RuntimeCall::System {..} |
 				RuntimeCall::Timestamp {..} |
@@ -344,43 +345,43 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				RuntimeCall::Proxy {..} |
 				RuntimeCall::Multisig {..}
 			),
-			ProxyType::Governance => {
-				matches!(
+            ProxyType::Governance => {
+                matches!(
 					c,
 					RuntimeCall::Treasury { .. } |
 						RuntimeCall::Bounties(..) |
 						RuntimeCall::ChildBounties(..)
 				)
-			},
-			ProxyType::CancelProxy => {
-				matches!(c, RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }))
-			},
-		}
-	}
-	fn is_superset(&self, o: &Self) -> bool {
-		match (self, o) {
-			(x, y) if x == y => true,
-			(ProxyType::Any, _) => true,
-			(_, ProxyType::Any) => false,
-			(ProxyType::NonTransfer, _) => true,
-			_ => false,
-		}
-	}
+            }
+            ProxyType::CancelProxy => {
+                matches!(c, RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }))
+            }
+        }
+    }
+    fn is_superset(&self, o: &Self) -> bool {
+        match (self, o) {
+            (x, y) if x == y => true,
+            (ProxyType::Any, _) => true,
+            (_, ProxyType::Any) => false,
+            (ProxyType::NonTransfer, _) => true,
+            _ => false,
+        }
+    }
 }
 
 impl pallet_proxy::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
-	type Currency = Balances;
-	type ProxyType = ProxyType;
-	type ProxyDepositBase = ProxyDepositBase;
-	type ProxyDepositFactor = ProxyDepositFactor;
-	type MaxProxies = MaxProxies;
-	type WeightInfo = weights::pallet_proxy::WeightInfo<Runtime>;
-	type MaxPending = MaxPending;
-	type CallHasher = BlakeTwo256;
-	type AnnouncementDepositBase = AnnouncementDepositBase;
-	type AnnouncementDepositFactor = AnnouncementDepositFactor;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type Currency = Balances;
+    type ProxyType = ProxyType;
+    type ProxyDepositBase = ProxyDepositBase;
+    type ProxyDepositFactor = ProxyDepositFactor;
+    type MaxProxies = MaxProxies;
+    type WeightInfo = weights::pallet_proxy::WeightInfo<Runtime>;
+    type MaxPending = MaxPending;
+    type CallHasher = BlakeTwo256;
+    type AnnouncementDepositBase = AnnouncementDepositBase;
+    type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
 parameter_types! {
@@ -390,14 +391,14 @@ parameter_types! {
 }
 
 impl pallet_vesting::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type BlockNumberToBalance = ConvertInto;
-	type BlockNumberProvider = System;
-	type MinVestedTransfer = MinVestedTransfer;
-	type WeightInfo = weights::pallet_vesting::WeightInfo<Runtime>;
-	type UnvestedFundsAllowedWithdrawReasons = UnvestedFundsAllowedWithdrawReasons;
-	const MAX_VESTING_SCHEDULES: u32 = 28;
+    type RuntimeEvent = RuntimeEvent;
+    type Currency = Balances;
+    type BlockNumberToBalance = ConvertInto;
+    type BlockNumberProvider = System;
+    type MinVestedTransfer = MinVestedTransfer;
+    type WeightInfo = weights::pallet_vesting::WeightInfo<Runtime>;
+    type UnvestedFundsAllowedWithdrawReasons = UnvestedFundsAllowedWithdrawReasons;
+    const MAX_VESTING_SCHEDULES: u32 = 28;
 }
 
 parameter_types! {
@@ -407,24 +408,24 @@ parameter_types! {
 }
 
 impl pallet_scheduler::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeOrigin = RuntimeOrigin;
-	type PalletsOrigin = OriginCaller;
-	type RuntimeCall = RuntimeCall;
-	type MaximumWeight = MaximumSchedulerWeight;
-	// one schedule is the founder allocation. We only allow RootOrigin here such that it takes a democracy proposal to change this schedule
-	type ScheduleOrigin = EnsureRoot<AccountId>;
-	type MaxScheduledPerBlock = MaxScheduledPerBlock;
-	type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
-	type OriginPrivilegeCmp = EqualPrivilegeOnly;
-	type Preimages = Preimage;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaximumSchedulerWeight;
+    // one schedule is the founder allocation. We only allow RootOrigin here such that it takes a democracy proposal to change this schedule
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type MaxScheduledPerBlock = MaxScheduledPerBlock;
+    type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type Preimages = Preimage;
 }
 
 impl pallet_utility::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeCall = RuntimeCall;
-	type PalletsOrigin = OriginCaller;
-	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeCall = RuntimeCall;
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -435,16 +436,16 @@ parameter_types! {
 }
 
 impl pallet_preimage::Config for Runtime {
-	type WeightInfo = weights::pallet_preimage::WeightInfo<Runtime>;
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type ManagerOrigin = EnsureRoot<AccountId>;
-	type Consideration = HoldConsideration<
-		AccountId,
-		Balances,
-		PreimageHoldReason,
-		LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
-	>;
+    type WeightInfo = weights::pallet_preimage::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type Currency = Balances;
+    type ManagerOrigin = EnsureRoot<AccountId>;
+    type Consideration = HoldConsideration<
+        AccountId,
+        Balances,
+        PreimageHoldReason,
+        LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
+    >;
 }
 
 parameter_types! {
@@ -454,22 +455,22 @@ parameter_types! {
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-	type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
-	type RuntimeEvent = RuntimeEvent;
-	type OnSystemEvent = ();
-	type SelfParaId = staging_parachain_info::Pallet<Runtime>;
-	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
-	type ReservedDmpWeight = ReservedDmpWeight;
-	type OutboundXcmpMessageSource = XcmpQueue;
-	type XcmpMessageHandler = XcmpQueue;
-	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
-	type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
-		Runtime,
-		RELAY_CHAIN_SLOT_DURATION_MILLIS,
-		BLOCK_PROCESSING_VELOCITY,
-		UNINCLUDED_SEGMENT_CAPACITY,
-	>;
+    type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type OnSystemEvent = ();
+    type SelfParaId = staging_parachain_info::Pallet<Runtime>;
+    type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
+    type ReservedDmpWeight = ReservedDmpWeight;
+    type OutboundXcmpMessageSource = XcmpQueue;
+    type XcmpMessageHandler = XcmpQueue;
+    type ReservedXcmpWeight = ReservedXcmpWeight;
+    type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+    type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
+        Runtime,
+        RELAY_CHAIN_SLOT_DURATION_MILLIS,
+        BLOCK_PROCESSING_VELOCITY,
+        UNINCLUDED_SEGMENT_CAPACITY,
+    >;
 }
 
 impl staging_parachain_info::Config for Runtime {}
@@ -481,26 +482,26 @@ parameter_types! {
 }
 
 impl pallet_message_queue::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = weights::pallet_message_queue::WeightInfo<Runtime>;
-	#[cfg(feature = "runtime-benchmarks")]
-	type MessageProcessor = pallet_message_queue::mock_helpers::NoopMessageProcessor<
-		cumulus_primitives_core::AggregateMessageOrigin,
-	>;
-	#[cfg(not(feature = "runtime-benchmarks"))]
-	type MessageProcessor = staging_xcm_builder::ProcessXcmMessage<
-		AggregateMessageOrigin,
-		staging_xcm_executor::XcmExecutor<xcm_config::XcmConfig>,
-		RuntimeCall,
-	>;
-	type Size = u32;
-	// The XCMP queue pallet is only ever able to handle the `Sibling(ParaId)` origin:
-	type QueueChangeHandler = NarrowOriginToSibling<XcmpQueue>;
-	type QueuePausedQuery = NarrowOriginToSibling<XcmpQueue>;
-	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
-	type MaxStale = sp_core::ConstU32<8>;
-	type ServiceWeight = MessageQueueServiceWeight;
-	type IdleMaxServiceWeight = ();
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = weights::pallet_message_queue::WeightInfo<Runtime>;
+    #[cfg(feature = "runtime-benchmarks")]
+    type MessageProcessor = pallet_message_queue::mock_helpers::NoopMessageProcessor<
+        cumulus_primitives_core::AggregateMessageOrigin,
+    >;
+    #[cfg(not(feature = "runtime-benchmarks"))]
+    type MessageProcessor = staging_xcm_builder::ProcessXcmMessage<
+        AggregateMessageOrigin,
+        staging_xcm_executor::XcmExecutor<xcm_config::XcmConfig>,
+        RuntimeCall,
+    >;
+    type Size = u32;
+    // The XCMP queue pallet is only ever able to handle the `Sibling(ParaId)` origin:
+    type QueueChangeHandler = NarrowOriginToSibling<XcmpQueue>;
+    type QueuePausedQuery = NarrowOriginToSibling<XcmpQueue>;
+    type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
+    type MaxStale = sp_core::ConstU32<8>;
+    type ServiceWeight = MessageQueueServiceWeight;
+    type IdleMaxServiceWeight = ();
 }
 
 parameter_types! {
@@ -514,11 +515,11 @@ parameter_types! {
 }
 
 impl pallet_aura::Config for Runtime {
-	type AuthorityId = AuraId;
-	type DisabledValidators = ();
-	type MaxAuthorities = MaxAuthorities;
-	type AllowMultipleBlocksPerSlot = ConstBool<false>;
-	type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Self>;
+    type AuthorityId = AuraId;
+    type DisabledValidators = ();
+    type MaxAuthorities = MaxAuthorities;
+    type AllowMultipleBlocksPerSlot = ConstBool<false>;
+    type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Self>;
 }
 
 // Integritee pallet
@@ -528,16 +529,16 @@ parameter_types! {
 }
 
 impl pallet_teerex::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type MomentsPerDay = MomentsPerDay;
-	type MaxAttestationRenewalPeriod = MaxAttestationRenewalPeriod;
-	type WeightInfo = weights::pallet_teerex::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type MomentsPerDay = MomentsPerDay;
+    type MaxAttestationRenewalPeriod = MaxAttestationRenewalPeriod;
+    type WeightInfo = weights::pallet_teerex::WeightInfo<Runtime>;
 }
 
 impl pallet_enclave_bridge::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = pallet_balances::Pallet<Runtime>;
-	type WeightInfo = weights::pallet_enclave_bridge::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type Currency = pallet_balances::Pallet<Runtime>;
+    type WeightInfo = weights::pallet_enclave_bridge::WeightInfo<Runtime>;
 }
 
 // Integritee pallet
@@ -546,8 +547,8 @@ parameter_types! {
 }
 
 impl pallet_sidechain::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = weights::pallet_sidechain::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = weights::pallet_sidechain::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -556,11 +557,11 @@ parameter_types! {
 
 // Integritee pallet
 impl pallet_claims::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type VestingSchedule = Vesting;
-	type Prefix = Prefix;
-	type MoveClaimOrigin = EnsureRoot<AccountId>;
-	type WeightInfo = weights::pallet_claims::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type VestingSchedule = Vesting;
+    type Prefix = Prefix;
+    type MoveClaimOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = weights::pallet_claims::WeightInfo<Runtime>;
 }
 parameter_types! {
 	pub const MaxWhitelistedReleases: u32 = 10;
@@ -569,10 +570,10 @@ parameter_types! {
 
 // Integritee pallet
 impl pallet_teeracle::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type WeightInfo = weights::pallet_teeracle::WeightInfo<Runtime>;
-	type MaxWhitelistedReleases = MaxWhitelistedReleases;
-	type MaxOracleBlobLen = MaxOracleBlobLen;
+    type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = weights::pallet_teeracle::WeightInfo<Runtime>;
+    type MaxWhitelistedReleases = MaxWhitelistedReleases;
+    type MaxOracleBlobLen = MaxOracleBlobLen;
 }
 
 parameter_types! {
@@ -592,39 +593,39 @@ parameter_types! {
 pub struct NoConversion;
 
 impl ConversionFromAssetBalance<u128, (), u128> for NoConversion {
-	type Error = ();
-	fn from_asset_balance(balance: Balance, _asset_id: ()) -> Result<Balance, Self::Error> {
-		return Ok(balance);
-	}
-	#[cfg(feature = "runtime-benchmarks")]
-	fn ensure_successful(_: ()) {}
+    type Error = ();
+    fn from_asset_balance(balance: Balance, _asset_id: ()) -> Result<Balance, Self::Error> {
+        return Ok(balance);
+    }
+    #[cfg(feature = "runtime-benchmarks")]
+    fn ensure_successful(_: ()) {}
 }
 
 impl pallet_treasury::Config for Runtime {
-	type PalletId = TreasuryPalletId;
-	type Currency = pallet_balances::Pallet<Runtime>;
-	type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
-	type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
-	type RuntimeEvent = RuntimeEvent;
-	type OnSlash = (); // No Proposal
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type ProposalBondMaximum = ProposalBondMaximum;
-	type SpendPeriod = SpendPeriod; //Cannot be 0: Error: Thread 'tokio-runtime-worker' panicked at 'attempt to calculate the remainder with a divisor of zero
-	type Burn = (); //No burn
-	type BurnDestination = (); //No burn
-	type SpendFunds = Bounties;
-	type SpendOrigin = EnsureWithSuccess<EnsureRoot<AccountId>, AccountId, MaxBalance>;
-	type MaxApprovals = MaxApprovals; //0:cannot approve any proposal
-	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
-	type AssetKind = ();
-	type Beneficiary = AccountId;
-	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
-	type Paymaster = PayFromAccount<Balances, TreasuryAccount>;
-	type BalanceConverter = NoConversion;
-	type PayoutPeriod = PayoutSpendPeriod;
-	#[cfg(feature = "runtime-benchmarks")]
-	type BenchmarkHelper = ();
+    type PalletId = TreasuryPalletId;
+    type Currency = pallet_balances::Pallet<Runtime>;
+    type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
+    type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
+    type RuntimeEvent = RuntimeEvent;
+    type OnSlash = (); // No Proposal
+    type ProposalBond = ProposalBond;
+    type ProposalBondMinimum = ProposalBondMinimum;
+    type ProposalBondMaximum = ProposalBondMaximum;
+    type SpendPeriod = SpendPeriod; //Cannot be 0: Error: Thread 'tokio-runtime-worker' panicked at 'attempt to calculate the remainder with a divisor of zero
+    type Burn = (); //No burn
+    type BurnDestination = (); //No burn
+    type SpendFunds = Bounties;
+    type SpendOrigin = EnsureWithSuccess<EnsureRoot<AccountId>, AccountId, MaxBalance>;
+    type MaxApprovals = MaxApprovals; //0:cannot approve any proposal
+    type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
+    type AssetKind = ();
+    type Beneficiary = AccountId;
+    type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
+    type Paymaster = PayFromAccount<Balances, TreasuryAccount>;
+    type BalanceConverter = NoConversion;
+    type PayoutPeriod = PayoutSpendPeriod;
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
 }
 
 parameter_types! {
@@ -639,18 +640,18 @@ parameter_types! {
 }
 
 impl pallet_bounties::Config for Runtime {
-	type BountyDepositBase = BountyDepositBase;
-	type BountyDepositPayoutDelay = BountyDepositPayoutDelay;
-	type BountyUpdatePeriod = BountyUpdatePeriod;
-	type CuratorDepositMultiplier = CuratorDepositMultiplier;
-	type CuratorDepositMin = CuratorDepositMin;
-	type CuratorDepositMax = CuratorDepositMax;
-	type BountyValueMinimum = BountyValueMinimum;
-	type ChildBountyManager = ChildBounties;
-	type DataDepositPerByte = DataDepositPerByte;
-	type RuntimeEvent = RuntimeEvent;
-	type MaximumReasonLength = MaximumReasonLength;
-	type WeightInfo = weights::pallet_bounties::WeightInfo<Runtime>;
+    type BountyDepositBase = BountyDepositBase;
+    type BountyDepositPayoutDelay = BountyDepositPayoutDelay;
+    type BountyUpdatePeriod = BountyUpdatePeriod;
+    type CuratorDepositMultiplier = CuratorDepositMultiplier;
+    type CuratorDepositMin = CuratorDepositMin;
+    type CuratorDepositMax = CuratorDepositMax;
+    type BountyValueMinimum = BountyValueMinimum;
+    type ChildBountyManager = ChildBounties;
+    type DataDepositPerByte = DataDepositPerByte;
+    type RuntimeEvent = RuntimeEvent;
+    type MaximumReasonLength = MaximumReasonLength;
+    type WeightInfo = weights::pallet_bounties::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -659,10 +660,10 @@ parameter_types! {
 }
 
 impl pallet_child_bounties::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type MaxActiveChildBountyCount = MaxActiveChildBountyCount;
-	type ChildBountyValueMinimum = ChildBountyValueMinimum;
-	type WeightInfo = weights::pallet_child_bounties::WeightInfo<Runtime>;
+    type RuntimeEvent = RuntimeEvent;
+    type MaxActiveChildBountyCount = MaxActiveChildBountyCount;
+    type ChildBountyValueMinimum = ChildBountyValueMinimum;
+    type WeightInfo = weights::pallet_child_bounties::WeightInfo<Runtime>;
 }
 
 /// Council collective instance declaration.
@@ -678,21 +679,21 @@ parameter_types! {
 }
 
 impl pallet_collective::Config<CouncilInstance> for Runtime {
-	type RuntimeOrigin = RuntimeOrigin;
-	type Proposal = RuntimeCall;
-	type RuntimeEvent = RuntimeEvent;
-	type MotionDuration = CouncilMotionDuration;
-	type MaxProposals = CouncilMaxProposals;
-	type MaxMembers = CouncilMaxMembers;
-	type DefaultVote = pallet_collective::PrimeDefaultVote;
-	type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
-	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
-	type MaxProposalWeight = MaxProposalWeight;
+    type RuntimeOrigin = RuntimeOrigin;
+    type Proposal = RuntimeCall;
+    type RuntimeEvent = RuntimeEvent;
+    type MotionDuration = CouncilMotionDuration;
+    type MaxProposals = CouncilMaxProposals;
+    type MaxMembers = CouncilMaxMembers;
+    type DefaultVote = pallet_collective::PrimeDefaultVote;
+    type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
+    type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
+    type MaxProposalWeight = MaxProposalWeight;
 }
 
 pub type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilInstance, 1, 2>,
+    EnsureRoot<AccountId>,
+    pallet_collective::EnsureProportionMoreThan<AccountId, CouncilInstance, 1, 2>,
 >;
 
 /// Technical committee collective instance declaration.
@@ -707,30 +708,30 @@ parameter_types! {
 }
 
 impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeEvent = RuntimeEvent;
-	type Proposal = RuntimeCall;
-	/// The maximum amount of time (in blocks) for technical committee members to vote on motions.
-	/// Motions may end in fewer blocks if enough votes are cast to determine the result.
-	type MotionDuration = TechnicalMotionDuration;
-	/// The maximum number of Proposlas that can be open in the technical committee at once.
-	type MaxProposals = TechnicalMaxProposals;
-	/// The maximum number of technical committee members.
-	type MaxMembers = TechnicalMaxMembers;
-	type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
-	type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
-	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
-	type MaxProposalWeight = MaxProposalWeight;
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeEvent = RuntimeEvent;
+    type Proposal = RuntimeCall;
+    /// The maximum amount of time (in blocks) for technical committee members to vote on motions.
+    /// Motions may end in fewer blocks if enough votes are cast to determine the result.
+    type MotionDuration = TechnicalMotionDuration;
+    /// The maximum number of Proposlas that can be open in the technical committee at once.
+    type MaxProposals = TechnicalMaxProposals;
+    /// The maximum number of technical committee members.
+    type MaxMembers = TechnicalMaxMembers;
+    type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
+    type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
+    type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
+    type MaxProposalWeight = MaxProposalWeight;
 }
 
 pub type EnsureRootOrMoreThanHalfTechnicalCommittee = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
+    EnsureRoot<AccountId>,
+    pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
 >;
 
 pub type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
-	EnsureRoot<AccountId>,
-	pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
+    EnsureRoot<AccountId>,
+    pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
 >;
 
 parameter_types! {
@@ -746,53 +747,53 @@ parameter_types! {
 }
 
 impl pallet_democracy::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
-	type EnactmentPeriod = EnactmentPeriod;
-	type LaunchPeriod = LaunchPeriod;
-	type VotingPeriod = VotingPeriod;
-	type VoteLockingPeriod = EnactmentPeriod;
-	type MinimumDeposit = MinimumDeposit;
-	//// Origin allowed to schedule a SuperMajorityApprove (default decline)
-	/// referendum once it is is legal for an externally proposed referendum
-	type ExternalOrigin = EnsureRootOrMoreThanHalfCouncil;
-	/// Origin allowed to schedule a majority-carries (Simple Majority)
-	/// referendum once it is legal for an externally proposed referendum
-	type ExternalMajorityOrigin = EnsureRootOrMoreThanHalfCouncil;
-	/// Origin allowed to schedule a SuperMajorityAgainst (default accept)
-	/// referendum once it is legal for an externally proposed referendum
-	type ExternalDefaultOrigin = EnsureRootOrMoreThanHalfCouncil;
-	/// Majority of the technical committee can have an ExternalMajority/ExternalDefault vote
-	/// be tabled immediately and with a shorter voting/enactment period.
-	type FastTrackOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
-	type InstantOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
-	type InstantAllowed = InstantAllowed;
-	type FastTrackVotingPeriod = FastTrackVotingPeriod;
-	// To cancel a proposal which has been passed.
-	type CancellationOrigin = EnsureRoot<AccountId>;
-	type BlacklistOrigin = EnsureRootOrMoreThanHalfCouncil;
-	// To cancel a proposal before it has been passed, the technical committee must be unanimous or
-	// Root must agree.
-	type CancelProposalOrigin = EnsureRootOrAllTechnicalCommittee;
-	// Any single technical committee member may veto a coming council proposal, however they can
-	// only do it once and it lasts only for the cooloff period.
-	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>;
-	type CooloffPeriod = CooloffPeriod;
-	type Slash = Treasury;
-	type Scheduler = Scheduler;
-	type PalletsOrigin = OriginCaller;
-	type MaxVotes = MaxVotes;
-	type WeightInfo = weights::pallet_democracy::WeightInfo<Runtime>;
-	type MaxProposals = MaxProposals;
-	type Preimages = Preimage;
-	type MaxDeposits = ConstU32<100>;
-	type MaxBlacklisted = ConstU32<100>;
-	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
+    type RuntimeEvent = RuntimeEvent;
+    type Currency = Balances;
+    type EnactmentPeriod = EnactmentPeriod;
+    type LaunchPeriod = LaunchPeriod;
+    type VotingPeriod = VotingPeriod;
+    type VoteLockingPeriod = EnactmentPeriod;
+    type MinimumDeposit = MinimumDeposit;
+    //// Origin allowed to schedule a SuperMajorityApprove (default decline)
+    /// referendum once it is is legal for an externally proposed referendum
+    type ExternalOrigin = EnsureRootOrMoreThanHalfCouncil;
+    /// Origin allowed to schedule a majority-carries (Simple Majority)
+    /// referendum once it is legal for an externally proposed referendum
+    type ExternalMajorityOrigin = EnsureRootOrMoreThanHalfCouncil;
+    /// Origin allowed to schedule a SuperMajorityAgainst (default accept)
+    /// referendum once it is legal for an externally proposed referendum
+    type ExternalDefaultOrigin = EnsureRootOrMoreThanHalfCouncil;
+    /// Majority of the technical committee can have an ExternalMajority/ExternalDefault vote
+    /// be tabled immediately and with a shorter voting/enactment period.
+    type FastTrackOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
+    type InstantOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
+    type InstantAllowed = InstantAllowed;
+    type FastTrackVotingPeriod = FastTrackVotingPeriod;
+    // To cancel a proposal which has been passed.
+    type CancellationOrigin = EnsureRoot<AccountId>;
+    type BlacklistOrigin = EnsureRootOrMoreThanHalfCouncil;
+    // To cancel a proposal before it has been passed, the technical committee must be unanimous or
+    // Root must agree.
+    type CancelProposalOrigin = EnsureRootOrAllTechnicalCommittee;
+    // Any single technical committee member may veto a coming council proposal, however they can
+    // only do it once and it lasts only for the cooloff period.
+    type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>;
+    type CooloffPeriod = CooloffPeriod;
+    type Slash = Treasury;
+    type Scheduler = Scheduler;
+    type PalletsOrigin = OriginCaller;
+    type MaxVotes = MaxVotes;
+    type WeightInfo = weights::pallet_democracy::WeightInfo<Runtime>;
+    type MaxProposals = MaxProposals;
+    type Preimages = Preimage;
+    type MaxDeposits = ConstU32<100>;
+    type MaxBlacklisted = ConstU32<100>;
+    type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 }
 
 impl orml_xcm::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type SovereignOrigin = EnsureRoot<AccountId>;
+    type RuntimeEvent = RuntimeEvent;
+    type SovereignOrigin = EnsureRoot<AccountId>;
 }
 
 pub type AssetBalance = Balance;
@@ -801,44 +802,44 @@ pub type AssetBalance = Balance;
 pub struct NoAssetCreators;
 
 impl EnsureOriginWithArg<RuntimeOrigin, AssetIdForTrustBackedAssets> for NoAssetCreators {
-	type Success = AccountId;
+    type Success = AccountId;
 
-	fn try_origin(
-		o: RuntimeOrigin,
-		_a: &AssetIdForTrustBackedAssets,
-	) -> sp_std::result::Result<Self::Success, RuntimeOrigin> {
-		return Err(o);
-	}
+    fn try_origin(
+        o: RuntimeOrigin,
+        _a: &AssetIdForTrustBackedAssets,
+    ) -> sp_std::result::Result<Self::Success, RuntimeOrigin> {
+        return Err(o);
+    }
 
-	#[cfg(feature = "runtime-benchmarks")]
-	fn try_successful_origin(_a: &AssetIdForTrustBackedAssets) -> Result<RuntimeOrigin, ()> {
-		Err(())
-	}
+    #[cfg(feature = "runtime-benchmarks")]
+    fn try_successful_origin(_a: &AssetIdForTrustBackedAssets) -> Result<RuntimeOrigin, ()> {
+        Err(())
+    }
 }
 
 pub type MainAssetsInstance = pallet_assets::Instance1;
 
 impl pallet_assets::Config<MainAssetsInstance> for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Balance = AssetBalance;
-	type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
-	type AssetId = AssetIdForTrustBackedAssets;
-	type AssetIdParameter = parity_scale_codec::Compact<AssetIdForTrustBackedAssets>;
-	type Currency = Balances;
-	type CreateOrigin = NoAssetCreators; //assets can only be created by root
-	type ForceOrigin = EnsureRoot<AccountId>;
-	type AssetDeposit = ConstU128<{ TEER }>;
-	type AssetAccountDeposit = ConstU128<{ TEER }>;
-	type MetadataDepositBase = ConstU128<{ TEER }>;
-	type MetadataDepositPerByte = ConstU128<{ 10 * MILLITEER }>;
-	type ApprovalDeposit = ConstU128<{ 10 * MILLITEER }>;
-	type StringLimit = ConstU32<50>;
-	type Freezer = ();
-	type Extra = ();
-	type CallbackHandle = ();
-	type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
-	#[cfg(feature = "runtime-benchmarks")]
-	type BenchmarkHelper = ();
+    type RuntimeEvent = RuntimeEvent;
+    type Balance = AssetBalance;
+    type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
+    type AssetId = AssetIdForTrustBackedAssets;
+    type AssetIdParameter = parity_scale_codec::Compact<AssetIdForTrustBackedAssets>;
+    type Currency = Balances;
+    type CreateOrigin = NoAssetCreators; //assets can only be created by root
+    type ForceOrigin = EnsureRoot<AccountId>;
+    type AssetDeposit = ConstU128<{ TEER }>;
+    type AssetAccountDeposit = ConstU128<{ TEER }>;
+    type MetadataDepositBase = ConstU128<{ TEER }>;
+    type MetadataDepositPerByte = ConstU128<{ 10 * MILLITEER }>;
+    type ApprovalDeposit = ConstU128<{ 10 * MILLITEER }>;
+    type StringLimit = ConstU32<50>;
+    type Freezer = ();
+    type Extra = ();
+    type CallbackHandle = ();
+    type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -846,62 +847,62 @@ pub struct AssetRegistryBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
 impl pallet_asset_registry::BenchmarkHelper<AssetIdForTrustBackedAssets>
-	for AssetRegistryBenchmarkHelper
+for AssetRegistryBenchmarkHelper
 {
-	fn get_registered_asset() -> AssetIdForTrustBackedAssets {
-		use sp_runtime::traits::StaticLookup;
+    fn get_registered_asset() -> AssetIdForTrustBackedAssets {
+        use sp_runtime::traits::StaticLookup;
 
-		let root = frame_system::RawOrigin::Root.into();
-		let asset_id = 1;
-		let caller = frame_benchmarking::whitelisted_caller();
-		let caller_lookup = <Runtime as frame_system::Config>::Lookup::unlookup(caller);
-		Assets::force_create(root, asset_id.into(), caller_lookup, true, 1)
-			.expect("Should have been able to force create asset");
-		asset_id
-	}
+        let root = frame_system::RawOrigin::Root.into();
+        let asset_id = 1;
+        let caller = frame_benchmarking::whitelisted_caller();
+        let caller_lookup = <Runtime as frame_system::Config>::Lookup::unlookup(caller);
+        Assets::force_create(root, asset_id.into(), caller_lookup, true, 1)
+            .expect("Should have been able to force create asset");
+        asset_id
+    }
 }
 
 impl pallet_asset_registry::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type ReserveAssetModifierOrigin = EnsureRoot<Self::AccountId>;
-	type Assets = Assets;
-	type WeightInfo = weights::pallet_asset_registry::WeightInfo<Runtime>;
-	#[cfg(feature = "runtime-benchmarks")]
-	type BenchmarkHelper = AssetRegistryBenchmarkHelper;
+    type RuntimeEvent = RuntimeEvent;
+    type ReserveAssetModifierOrigin = EnsureRoot<Self::AccountId>;
+    type Assets = Assets;
+    type WeightInfo = weights::pallet_asset_registry::WeightInfo<Runtime>;
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = AssetRegistryBenchmarkHelper;
 }
 
 pub type NativeAndAssets = UnionOf<
-	Balances,
-	Assets,
-	NativeFromLeft,
-	NativeOrWithId<AssetIdForTrustBackedAssets>,
-	AccountId,
+    Balances,
+    Assets,
+    NativeFromLeft,
+    NativeOrWithId<AssetIdForTrustBackedAssets>,
+    AccountId,
 >;
 pub type AscendingLocator = Ascending<AccountId, NativeOrWithId<AssetIdForTrustBackedAssets>>;
 pub type WithFirstAssetLocator =
-	WithFirstAsset<Native, AccountId, NativeOrWithId<AssetIdForTrustBackedAssets>>;
+WithFirstAsset<Native, AccountId, NativeOrWithId<AssetIdForTrustBackedAssets>>;
 
 impl pallet_asset_conversion::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Balance = Balance;
-	type HigherPrecisionBalance = sp_core::U256;
-	type AssetKind = NativeOrWithId<AssetIdForTrustBackedAssets>;
-	type Assets = NativeAndAssets;
-	type PoolId = (Self::AssetKind, Self::AssetKind);
-	type PoolLocator = Chain<WithFirstAssetLocator, AscendingLocator>;
-	type PoolAssetId = u32;
-	type PoolAssets = PoolAssets;
-	type PoolSetupFee = ConstU128<0>; // Asset class deposit fees are sufficient to prevent spam
-	type PoolSetupFeeAsset = Native;
-	type PoolSetupFeeTarget = ResolveAssetTo<AssetConversionOrigin, Self::Assets>;
-	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;
-	type LPFee = ConstU32<3>; // 0.3% swap fee
-	type PalletId = AssetConversionPalletId;
-	type MaxSwapPathLength = ConstU32<3>;
-	type MintMinLiquidity = ConstU128<100>;
-	type WeightInfo = weights::pallet_asset_conversion::WeightInfo<Runtime>;
-	#[cfg(feature = "runtime-benchmarks")]
-	type BenchmarkHelper = ();
+    type RuntimeEvent = RuntimeEvent;
+    type Balance = Balance;
+    type HigherPrecisionBalance = sp_core::U256;
+    type AssetKind = NativeOrWithId<AssetIdForTrustBackedAssets>;
+    type Assets = NativeAndAssets;
+    type PoolId = (Self::AssetKind, Self::AssetKind);
+    type PoolLocator = Chain<WithFirstAssetLocator, AscendingLocator>;
+    type PoolAssetId = u32;
+    type PoolAssets = PoolAssets;
+    type PoolSetupFee = ConstU128<0>; // Asset class deposit fees are sufficient to prevent spam
+    type PoolSetupFeeAsset = Native;
+    type PoolSetupFeeTarget = ResolveAssetTo<AssetConversionOrigin, Self::Assets>;
+    type LiquidityWithdrawalFee = LiquidityWithdrawalFee;
+    type LPFee = ConstU32<3>; // 0.3% swap fee
+    type PalletId = AssetConversionPalletId;
+    type MaxSwapPathLength = ConstU32<3>;
+    type MintMinLiquidity = ConstU128<100>;
+    type WeightInfo = weights::pallet_asset_conversion::WeightInfo<Runtime>;
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
 }
 
 parameter_types! {
@@ -919,28 +920,28 @@ ord_parameter_types! {
 pub type PoolAssetsInstance = pallet_assets::Instance2;
 
 impl pallet_assets::Config<PoolAssetsInstance> for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type Balance = Balance;
-	type RemoveItemsLimit = ConstU32<1000>;
-	type AssetId = u32;
-	type AssetIdParameter = u32;
-	type Currency = Balances;
-	type CreateOrigin =
-		AsEnsureOriginWithArg<EnsureSignedBy<AssetConversionOrigin, sp_runtime::AccountId32>>;
-	type ForceOrigin = EnsureRoot<AccountId>;
-	// Deposits are zero because creation/admin is limited to Asset Conversion pallet.
-	type AssetDeposit = ConstU128<0>;
-	type AssetAccountDeposit = ConstU128<0>;
-	type MetadataDepositBase = ConstU128<0>;
-	type MetadataDepositPerByte = ConstU128<0>;
-	type ApprovalDeposit = ApprovalDeposit;
-	type StringLimit = ConstU32<50>;
-	type Freezer = ();
-	type Extra = ();
-	type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
-	type CallbackHandle = ();
-	#[cfg(feature = "runtime-benchmarks")]
-	type BenchmarkHelper = ();
+    type RuntimeEvent = RuntimeEvent;
+    type Balance = Balance;
+    type RemoveItemsLimit = ConstU32<1000>;
+    type AssetId = u32;
+    type AssetIdParameter = u32;
+    type Currency = Balances;
+    type CreateOrigin =
+    AsEnsureOriginWithArg<EnsureSignedBy<AssetConversionOrigin, sp_runtime::AccountId32>>;
+    type ForceOrigin = EnsureRoot<AccountId>;
+    // Deposits are zero because creation/admin is limited to Asset Conversion pallet.
+    type AssetDeposit = ConstU128<0>;
+    type AssetAccountDeposit = ConstU128<0>;
+    type MetadataDepositBase = ConstU128<0>;
+    type MetadataDepositPerByte = ConstU128<0>;
+    type ApprovalDeposit = ApprovalDeposit;
+    type StringLimit = ConstU32<50>;
+    type Freezer = ();
+    type Extra = ();
+    type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
+    type CallbackHandle = ();
+    #[cfg(feature = "runtime-benchmarks")]
+    type BenchmarkHelper = ();
 }
 
 construct_runtime!(
@@ -1002,18 +1003,18 @@ construct_runtime!(
 
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
-	frame_system::CheckNonZeroSender<Runtime>,
-	frame_system::CheckSpecVersion<Runtime>,
-	frame_system::CheckTxVersion<Runtime>,
-	frame_system::CheckGenesis<Runtime>,
-	frame_system::CheckEra<Runtime>,
-	frame_system::CheckNonce<Runtime>,
-	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+    frame_system::CheckNonZeroSender<Runtime>,
+    frame_system::CheckSpecVersion<Runtime>,
+    frame_system::CheckTxVersion<Runtime>,
+    frame_system::CheckGenesis<Runtime>,
+    frame_system::CheckEra<Runtime>,
+    frame_system::CheckNonce<Runtime>,
+    frame_system::CheckWeight<Runtime>,
+    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
-	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Block type as expected by this runtime.
@@ -1024,16 +1025,19 @@ pub type SignedBlock = generic::SignedBlock<Block>;
 pub type BlockId = generic::BlockId<Block>;
 
 /// Migrations to apply on runtime upgrade.
-pub type Migrations = (cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,);
+pub type Migrations = (
+    migrations::scheduler::v4::PurgeV4Agenda<Runtime>,
+    cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
+);
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
-	Runtime,
-	Block,
-	frame_system::ChainContext<Runtime>,
-	Runtime,
-	AllPalletsWithSystem, // Solochain: AllPalletsReversedWithSystemFirst, Statemint: AllPallets. Which one to take?
-	Migrations,
+    Runtime,
+    Block,
+    frame_system::ChainContext<Runtime>,
+    Runtime,
+    AllPalletsWithSystem, // Solochain: AllPalletsReversedWithSystemFirst, Statemint: AllPallets. Which one to take?
+    Migrations,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -1042,7 +1046,7 @@ extern crate frame_benchmarking;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benches {
-	define_benchmarks!(
+    define_benchmarks!(
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_asset_conversion, AssetConversion]
 		[pallet_asset_registry, AssetRegistry]

--- a/polkadot-parachains/integritee-runtime/src/lib.rs
+++ b/polkadot-parachains/integritee-runtime/src/lib.rs
@@ -26,44 +26,44 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
 use cumulus_primitives_core::AggregateMessageOrigin;
 pub use frame_support::{
-    construct_runtime,
-    dispatch::DispatchClass,
-    pallet_prelude::Get,
-    parameter_types,
-    traits::{
-        EitherOfDiverse, Everything, IsInVec, Nothing, PalletInfoAccess, Randomness,
-        WithdrawReasons,
-    },
-    weights::{
-        constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
-        IdentityFee, Weight,
-    },
-    PalletId, StorageValue,
+	construct_runtime,
+	dispatch::DispatchClass,
+	pallet_prelude::Get,
+	parameter_types,
+	traits::{
+		EitherOfDiverse, Everything, IsInVec, Nothing, PalletInfoAccess, Randomness,
+		WithdrawReasons,
+	},
+	weights::{
+		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight},
+		IdentityFee, Weight,
+	},
+	PalletId, StorageValue,
 };
 use frame_support::{
-    derive_impl,
-    genesis_builder_helper::{build_config, create_default_config},
-    ord_parameter_types,
-    traits::{
-        fungible::{HoldConsideration, NativeFromLeft, NativeOrWithId, UnionOf},
-        tokens::{imbalance::ResolveAssetTo, ConversionFromAssetBalance, PayFromAccount},
-        AsEnsureOriginWithArg, ConstBool, EnsureOriginWithArg, EqualPrivilegeOnly, Imbalance,
-        InstanceFilter, LinearStoragePrice, OnUnbalanced,
-    },
-    weights::ConstantMultiplier,
+	derive_impl,
+	genesis_builder_helper::{build_config, create_default_config},
+	ord_parameter_types,
+	traits::{
+		fungible::{HoldConsideration, NativeFromLeft, NativeOrWithId, UnionOf},
+		tokens::{imbalance::ResolveAssetTo, ConversionFromAssetBalance, PayFromAccount},
+		AsEnsureOriginWithArg, ConstBool, EnsureOriginWithArg, EqualPrivilegeOnly, Imbalance,
+		InstanceFilter, LinearStoragePrice, OnUnbalanced,
+	},
+	weights::ConstantMultiplier,
 };
 use frame_system::{
-    limits::{BlockLength, BlockWeights},
-    EnsureRoot, EnsureSignedBy, EnsureWithSuccess,
+	limits::{BlockLength, BlockWeights},
+	EnsureRoot, EnsureSignedBy, EnsureWithSuccess,
 };
 use integritee_parachains_common::{
-    fee::{SlowAdjustingFeeUpdate, WeightToFee},
-    AuraId, AVERAGE_ON_INITIALIZE_RATIO, BLOCK_PROCESSING_VELOCITY, DAYS, HOURS,
-    MAXIMUM_BLOCK_WEIGHT, MINUTES, NORMAL_DISPATCH_RATIO, RELAY_CHAIN_SLOT_DURATION_MILLIS,
-    SLOT_DURATION, UNINCLUDED_SEGMENT_CAPACITY,
+	fee::{SlowAdjustingFeeUpdate, WeightToFee},
+	AuraId, AVERAGE_ON_INITIALIZE_RATIO, BLOCK_PROCESSING_VELOCITY, DAYS, HOURS,
+	MAXIMUM_BLOCK_WEIGHT, MINUTES, NORMAL_DISPATCH_RATIO, RELAY_CHAIN_SLOT_DURATION_MILLIS,
+	SLOT_DURATION, UNINCLUDED_SEGMENT_CAPACITY,
 };
 pub use integritee_parachains_common::{
-    AccountId, Address, Balance, BlockNumber, Hash, Header, Nonce, Signature, MILLISECS_PER_BLOCK,
+	AccountId, Address, Balance, BlockNumber, Hash, Header, Nonce, Signature, MILLISECS_PER_BLOCK,
 };
 use pallet_asset_conversion::{Ascending, Chain, WithFirstAsset};
 pub use pallet_balances::Call as BalancesCall;
@@ -82,10 +82,10 @@ use sp_core::{crypto::KeyTypeId, ConstU128, ConstU32, OpaqueMetadata};
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{
-    create_runtime_str, generic, impl_opaque_keys,
-    traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, ConvertInto, IdentityLookup},
-    transaction_validity::{TransactionSource, TransactionValidity},
-    ApplyExtrinsicResult, RuntimeDebug,
+	create_runtime_str, generic, impl_opaque_keys,
+	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, ConvertInto, IdentityLookup},
+	transaction_validity::{TransactionSource, TransactionValidity},
+	ApplyExtrinsicResult, RuntimeDebug,
 };
 pub use sp_runtime::{Perbill, Permill};
 use sp_std::prelude::*;
@@ -96,8 +96,8 @@ use sp_version::RuntimeVersion;
 mod helpers;
 mod weights;
 
-pub mod xcm_config;
 mod migrations;
+pub mod xcm_config;
 
 pub type SessionHandlers = ();
 
@@ -106,7 +106,7 @@ pub type SessionHandlers = ();
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
 /// to even the core data structures.
 pub mod opaque {
-    pub use integritee_parachains_common::opaque::*;
+	pub use integritee_parachains_common::opaque::*;
 }
 
 impl_opaque_keys! {
@@ -117,14 +117,14 @@ impl_opaque_keys! {
 
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-    spec_name: create_runtime_str!("integritee-parachain"),
-    impl_name: create_runtime_str!("integritee-full"),
-    authoring_version: 2,
-    spec_version: 51,
-    impl_version: 1,
-    apis: RUNTIME_API_VERSIONS,
-    transaction_version: 7,
-    state_version: 0,
+	spec_name: create_runtime_str!("integritee-parachain"),
+	impl_name: create_runtime_str!("integritee-full"),
+	authoring_version: 2,
+	spec_version: 51,
+	impl_version: 1,
+	apis: RUNTIME_API_VERSIONS,
+	transaction_version: 7,
+	state_version: 0,
 };
 
 pub const TEER: Balance = 1_000_000_000_000;
@@ -133,7 +133,7 @@ pub const MICROTEER: Balance = 1_000_000;
 
 // Logic from Polkadot/Kusama.
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
-    items as Balance * 20 * TEER + (bytes as Balance) * 1_000 * MICROTEER
+	items as Balance * 20 * TEER + (bytes as Balance) * 1_000 * MICROTEER
 }
 
 /// A timestamp: milliseconds since the unix epoch.
@@ -142,28 +142,28 @@ pub type Moment = u64;
 /// The version information used to identify this runtime when compiled natively.
 #[cfg(feature = "std")]
 pub fn native_version() -> NativeVersion {
-    NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
+	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
 pub struct DealWithFees;
 
 impl OnUnbalanced<pallet_balances::NegativeImbalance<Runtime>> for DealWithFees {
-    fn on_unbalanceds<B>(
-        mut fees_then_tips: impl Iterator<Item=pallet_balances::NegativeImbalance<Runtime>>,
-    ) {
-        if let Some(fees) = fees_then_tips.next() {
-            // for fees, 1% to treasury, 99% burned
-            // TODO: apply burning function based on cumulative number of extrinsics (#32)
-            let mut split = fees.ration(1, 99);
+	fn on_unbalanceds<B>(
+		mut fees_then_tips: impl Iterator<Item = pallet_balances::NegativeImbalance<Runtime>>,
+	) {
+		if let Some(fees) = fees_then_tips.next() {
+			// for fees, 1% to treasury, 99% burned
+			// TODO: apply burning function based on cumulative number of extrinsics (#32)
+			let mut split = fees.ration(1, 99);
 
-            // tips (voluntary extra fees) go to the treasury entirely. no burning
-            if let Some(tips) = fees_then_tips.next() {
-                tips.merge_into(&mut split.0);
-            }
-            Treasury::on_unbalanced(split.0);
-            // burn remainder by not assigning imbalance to someone
-        }
-    }
+			// tips (voluntary extra fees) go to the treasury entirely. no burning
+			if let Some(tips) = fees_then_tips.next() {
+				tips.merge_into(&mut split.0);
+			}
+			Treasury::on_unbalanced(split.0);
+			// burn remainder by not assigning imbalance to someone
+		}
+	}
 }
 
 parameter_types! {
@@ -197,21 +197,21 @@ parameter_types! {
 /// but overridden as needed.
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Runtime {
-    type BaseCallFilter = Everything;
-    type BlockWeights = RuntimeBlockWeights;
-    type BlockLength = RuntimeBlockLength;
-    type Block = Block;
-    type AccountId = AccountId;
-    type Nonce = Nonce;
-    type Hash = Hash;
-    type BlockHashCount = BlockHashCount;
-    type DbWeight = RocksDbWeight;
-    type Version = Version;
-    type AccountData = pallet_balances::AccountData<Balance>;
-    type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
-    type SS58Prefix = SS58Prefix;
-    type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-    type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type BaseCallFilter = Everything;
+	type BlockWeights = RuntimeBlockWeights;
+	type BlockLength = RuntimeBlockLength;
+	type Block = Block;
+	type AccountId = AccountId;
+	type Nonce = Nonce;
+	type Hash = Hash;
+	type BlockHashCount = BlockHashCount;
+	type DbWeight = RocksDbWeight;
+	type Version = Version;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
 parameter_types! {
@@ -219,11 +219,11 @@ parameter_types! {
 }
 
 impl pallet_timestamp::Config for Runtime {
-    /// A timestamp: milliseconds since the unix epoch.
-    type Moment = Moment;
-    type OnTimestampSet = ();
-    type MinimumPeriod = MinimumPeriod;
-    type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
+	/// A timestamp: milliseconds since the unix epoch.
+	type Moment = Moment;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = weights::pallet_timestamp::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -237,30 +237,30 @@ parameter_types! {
 }
 
 impl pallet_balances::Config for Runtime {
-    type MaxLocks = MaxLocks;
-    /// The type for recording an account's balance.
-    type Balance = Balance;
-    /// The ubiquitous event type.
-    type RuntimeEvent = RuntimeEvent;
-    type DustRemoval = ();
-    type ExistentialDeposit = ExistentialDeposit;
-    type AccountStore = System;
-    type WeightInfo = weights::pallet_balances::WeightInfo<Runtime>;
-    type MaxReserves = MaxReserves;
-    type ReserveIdentifier = [u8; 8];
-    type RuntimeHoldReason = RuntimeHoldReason;
-    type RuntimeFreezeReason = ();
-    type FreezeIdentifier = ();
-    type MaxFreezes = ();
+	type MaxLocks = MaxLocks;
+	/// The type for recording an account's balance.
+	type Balance = Balance;
+	/// The ubiquitous event type.
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = weights::pallet_balances::WeightInfo<Runtime>;
+	type MaxReserves = MaxReserves;
+	type ReserveIdentifier = [u8; 8];
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
 }
 
 impl pallet_transaction_payment::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees>;
-    type WeightToFee = WeightToFee;
-    type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
-    type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
-    type OperationalFeeMultiplier = OperationalFeeMultiplier;
+	type RuntimeEvent = RuntimeEvent;
+	type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees>;
+	type WeightToFee = WeightToFee;
+	type LengthToFee = ConstantMultiplier<Balance, TransactionByteFee>;
+	type FeeMultiplierUpdate = SlowAdjustingFeeUpdate<Self>;
+	type OperationalFeeMultiplier = OperationalFeeMultiplier;
 }
 
 parameter_types! {
@@ -272,13 +272,13 @@ parameter_types! {
 }
 
 impl pallet_multisig::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
-    type Currency = Balances;
-    type DepositBase = DepositBase;
-    type DepositFactor = DepositFactor;
-    type MaxSignatories = MaxSignatories;
-    type WeightInfo = weights::pallet_multisig::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeCall = RuntimeCall;
+	type Currency = Balances;
+	type DepositBase = DepositBase;
+	type DepositFactor = DepositFactor;
+	type MaxSignatories = MaxSignatories;
+	type WeightInfo = weights::pallet_multisig::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -294,39 +294,39 @@ parameter_types! {
 
 /// The type used to represent the kinds of proxying allowed.
 #[derive(
-    Copy,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Encode,
-    Decode,
-    RuntimeDebug,
-    MaxEncodedLen,
-    TypeInfo,
+	Copy,
+	Clone,
+	Eq,
+	PartialEq,
+	Ord,
+	PartialOrd,
+	Encode,
+	Decode,
+	RuntimeDebug,
+	MaxEncodedLen,
+	TypeInfo,
 )]
 pub enum ProxyType {
-    Any,         // Any transactions.
-    NonTransfer, // Any type of transaction except balance transfers (including vested transfers)
-    Governance,
-    // Staking = 3,
-    // IdentityJudgement = 4,
-    CancelProxy,
-    // Auction,
+	Any,         // Any transactions.
+	NonTransfer, // Any type of transaction except balance transfers (including vested transfers)
+	Governance,
+	// Staking = 3,
+	// IdentityJudgement = 4,
+	CancelProxy,
+	// Auction,
 }
 
 impl Default for ProxyType {
-    fn default() -> Self {
-        Self::Any
-    }
+	fn default() -> Self {
+		Self::Any
+	}
 }
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
-    fn filter(&self, c: &RuntimeCall) -> bool {
-        match self {
-            ProxyType::Any => true,
-            ProxyType::NonTransfer => matches!(
+	fn filter(&self, c: &RuntimeCall) -> bool {
+		match self {
+			ProxyType::Any => true,
+			ProxyType::NonTransfer => matches!(
 				c,
 				RuntimeCall::System {..} |
 				RuntimeCall::Timestamp {..} |
@@ -345,43 +345,43 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				RuntimeCall::Proxy {..} |
 				RuntimeCall::Multisig {..}
 			),
-            ProxyType::Governance => {
-                matches!(
+			ProxyType::Governance => {
+				matches!(
 					c,
 					RuntimeCall::Treasury { .. } |
 						RuntimeCall::Bounties(..) |
 						RuntimeCall::ChildBounties(..)
 				)
-            }
-            ProxyType::CancelProxy => {
-                matches!(c, RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }))
-            }
-        }
-    }
-    fn is_superset(&self, o: &Self) -> bool {
-        match (self, o) {
-            (x, y) if x == y => true,
-            (ProxyType::Any, _) => true,
-            (_, ProxyType::Any) => false,
-            (ProxyType::NonTransfer, _) => true,
-            _ => false,
-        }
-    }
+			},
+			ProxyType::CancelProxy => {
+				matches!(c, RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }))
+			},
+		}
+	}
+	fn is_superset(&self, o: &Self) -> bool {
+		match (self, o) {
+			(x, y) if x == y => true,
+			(ProxyType::Any, _) => true,
+			(_, ProxyType::Any) => false,
+			(ProxyType::NonTransfer, _) => true,
+			_ => false,
+		}
+	}
 }
 
 impl pallet_proxy::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
-    type Currency = Balances;
-    type ProxyType = ProxyType;
-    type ProxyDepositBase = ProxyDepositBase;
-    type ProxyDepositFactor = ProxyDepositFactor;
-    type MaxProxies = MaxProxies;
-    type WeightInfo = weights::pallet_proxy::WeightInfo<Runtime>;
-    type MaxPending = MaxPending;
-    type CallHasher = BlakeTwo256;
-    type AnnouncementDepositBase = AnnouncementDepositBase;
-    type AnnouncementDepositFactor = AnnouncementDepositFactor;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeCall = RuntimeCall;
+	type Currency = Balances;
+	type ProxyType = ProxyType;
+	type ProxyDepositBase = ProxyDepositBase;
+	type ProxyDepositFactor = ProxyDepositFactor;
+	type MaxProxies = MaxProxies;
+	type WeightInfo = weights::pallet_proxy::WeightInfo<Runtime>;
+	type MaxPending = MaxPending;
+	type CallHasher = BlakeTwo256;
+	type AnnouncementDepositBase = AnnouncementDepositBase;
+	type AnnouncementDepositFactor = AnnouncementDepositFactor;
 }
 
 parameter_types! {
@@ -391,14 +391,14 @@ parameter_types! {
 }
 
 impl pallet_vesting::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Currency = Balances;
-    type BlockNumberToBalance = ConvertInto;
-    type BlockNumberProvider = System;
-    type MinVestedTransfer = MinVestedTransfer;
-    type WeightInfo = weights::pallet_vesting::WeightInfo<Runtime>;
-    type UnvestedFundsAllowedWithdrawReasons = UnvestedFundsAllowedWithdrawReasons;
-    const MAX_VESTING_SCHEDULES: u32 = 28;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type BlockNumberToBalance = ConvertInto;
+	type BlockNumberProvider = System;
+	type MinVestedTransfer = MinVestedTransfer;
+	type WeightInfo = weights::pallet_vesting::WeightInfo<Runtime>;
+	type UnvestedFundsAllowedWithdrawReasons = UnvestedFundsAllowedWithdrawReasons;
+	const MAX_VESTING_SCHEDULES: u32 = 28;
 }
 
 parameter_types! {
@@ -408,24 +408,24 @@ parameter_types! {
 }
 
 impl pallet_scheduler::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeOrigin = RuntimeOrigin;
-    type PalletsOrigin = OriginCaller;
-    type RuntimeCall = RuntimeCall;
-    type MaximumWeight = MaximumSchedulerWeight;
-    // one schedule is the founder allocation. We only allow RootOrigin here such that it takes a democracy proposal to change this schedule
-    type ScheduleOrigin = EnsureRoot<AccountId>;
-    type MaxScheduledPerBlock = MaxScheduledPerBlock;
-    type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
-    type OriginPrivilegeCmp = EqualPrivilegeOnly;
-    type Preimages = Preimage;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeOrigin = RuntimeOrigin;
+	type PalletsOrigin = OriginCaller;
+	type RuntimeCall = RuntimeCall;
+	type MaximumWeight = MaximumSchedulerWeight;
+	// one schedule is the founder allocation. We only allow RootOrigin here such that it takes a democracy proposal to change this schedule
+	type ScheduleOrigin = EnsureRoot<AccountId>;
+	type MaxScheduledPerBlock = MaxScheduledPerBlock;
+	type WeightInfo = weights::pallet_scheduler::WeightInfo<Runtime>;
+	type OriginPrivilegeCmp = EqualPrivilegeOnly;
+	type Preimages = Preimage;
 }
 
 impl pallet_utility::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
-    type PalletsOrigin = OriginCaller;
-    type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type RuntimeCall = RuntimeCall;
+	type PalletsOrigin = OriginCaller;
+	type WeightInfo = weights::pallet_utility::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -436,16 +436,16 @@ parameter_types! {
 }
 
 impl pallet_preimage::Config for Runtime {
-    type WeightInfo = weights::pallet_preimage::WeightInfo<Runtime>;
-    type RuntimeEvent = RuntimeEvent;
-    type Currency = Balances;
-    type ManagerOrigin = EnsureRoot<AccountId>;
-    type Consideration = HoldConsideration<
-        AccountId,
-        Balances,
-        PreimageHoldReason,
-        LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
-    >;
+	type WeightInfo = weights::pallet_preimage::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type ManagerOrigin = EnsureRoot<AccountId>;
+	type Consideration = HoldConsideration<
+		AccountId,
+		Balances,
+		PreimageHoldReason,
+		LinearStoragePrice<PreimageBaseDeposit, PreimageByteDeposit, Balance>,
+	>;
 }
 
 parameter_types! {
@@ -455,22 +455,22 @@ parameter_types! {
 }
 
 impl cumulus_pallet_parachain_system::Config for Runtime {
-    type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
-    type RuntimeEvent = RuntimeEvent;
-    type OnSystemEvent = ();
-    type SelfParaId = staging_parachain_info::Pallet<Runtime>;
-    type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
-    type ReservedDmpWeight = ReservedDmpWeight;
-    type OutboundXcmpMessageSource = XcmpQueue;
-    type XcmpMessageHandler = XcmpQueue;
-    type ReservedXcmpWeight = ReservedXcmpWeight;
-    type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
-    type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
-        Runtime,
-        RELAY_CHAIN_SLOT_DURATION_MILLIS,
-        BLOCK_PROCESSING_VELOCITY,
-        UNINCLUDED_SEGMENT_CAPACITY,
-    >;
+	type WeightInfo = weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type OnSystemEvent = ();
+	type SelfParaId = staging_parachain_info::Pallet<Runtime>;
+	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
+	type ReservedDmpWeight = ReservedDmpWeight;
+	type OutboundXcmpMessageSource = XcmpQueue;
+	type XcmpMessageHandler = XcmpQueue;
+	type ReservedXcmpWeight = ReservedXcmpWeight;
+	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
+		Runtime,
+		RELAY_CHAIN_SLOT_DURATION_MILLIS,
+		BLOCK_PROCESSING_VELOCITY,
+		UNINCLUDED_SEGMENT_CAPACITY,
+	>;
 }
 
 impl staging_parachain_info::Config for Runtime {}
@@ -482,26 +482,26 @@ parameter_types! {
 }
 
 impl pallet_message_queue::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = weights::pallet_message_queue::WeightInfo<Runtime>;
-    #[cfg(feature = "runtime-benchmarks")]
-    type MessageProcessor = pallet_message_queue::mock_helpers::NoopMessageProcessor<
-        cumulus_primitives_core::AggregateMessageOrigin,
-    >;
-    #[cfg(not(feature = "runtime-benchmarks"))]
-    type MessageProcessor = staging_xcm_builder::ProcessXcmMessage<
-        AggregateMessageOrigin,
-        staging_xcm_executor::XcmExecutor<xcm_config::XcmConfig>,
-        RuntimeCall,
-    >;
-    type Size = u32;
-    // The XCMP queue pallet is only ever able to handle the `Sibling(ParaId)` origin:
-    type QueueChangeHandler = NarrowOriginToSibling<XcmpQueue>;
-    type QueuePausedQuery = NarrowOriginToSibling<XcmpQueue>;
-    type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
-    type MaxStale = sp_core::ConstU32<8>;
-    type ServiceWeight = MessageQueueServiceWeight;
-    type IdleMaxServiceWeight = ();
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = weights::pallet_message_queue::WeightInfo<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type MessageProcessor = pallet_message_queue::mock_helpers::NoopMessageProcessor<
+		cumulus_primitives_core::AggregateMessageOrigin,
+	>;
+	#[cfg(not(feature = "runtime-benchmarks"))]
+	type MessageProcessor = staging_xcm_builder::ProcessXcmMessage<
+		AggregateMessageOrigin,
+		staging_xcm_executor::XcmExecutor<xcm_config::XcmConfig>,
+		RuntimeCall,
+	>;
+	type Size = u32;
+	// The XCMP queue pallet is only ever able to handle the `Sibling(ParaId)` origin:
+	type QueueChangeHandler = NarrowOriginToSibling<XcmpQueue>;
+	type QueuePausedQuery = NarrowOriginToSibling<XcmpQueue>;
+	type HeapSize = sp_core::ConstU32<{ 64 * 1024 }>;
+	type MaxStale = sp_core::ConstU32<8>;
+	type ServiceWeight = MessageQueueServiceWeight;
+	type IdleMaxServiceWeight = ();
 }
 
 parameter_types! {
@@ -515,11 +515,11 @@ parameter_types! {
 }
 
 impl pallet_aura::Config for Runtime {
-    type AuthorityId = AuraId;
-    type DisabledValidators = ();
-    type MaxAuthorities = MaxAuthorities;
-    type AllowMultipleBlocksPerSlot = ConstBool<false>;
-    type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Self>;
+	type AuthorityId = AuraId;
+	type DisabledValidators = ();
+	type MaxAuthorities = MaxAuthorities;
+	type AllowMultipleBlocksPerSlot = ConstBool<false>;
+	type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Self>;
 }
 
 // Integritee pallet
@@ -529,16 +529,16 @@ parameter_types! {
 }
 
 impl pallet_teerex::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type MomentsPerDay = MomentsPerDay;
-    type MaxAttestationRenewalPeriod = MaxAttestationRenewalPeriod;
-    type WeightInfo = weights::pallet_teerex::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type MomentsPerDay = MomentsPerDay;
+	type MaxAttestationRenewalPeriod = MaxAttestationRenewalPeriod;
+	type WeightInfo = weights::pallet_teerex::WeightInfo<Runtime>;
 }
 
 impl pallet_enclave_bridge::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Currency = pallet_balances::Pallet<Runtime>;
-    type WeightInfo = weights::pallet_enclave_bridge::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = pallet_balances::Pallet<Runtime>;
+	type WeightInfo = weights::pallet_enclave_bridge::WeightInfo<Runtime>;
 }
 
 // Integritee pallet
@@ -547,8 +547,8 @@ parameter_types! {
 }
 
 impl pallet_sidechain::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = weights::pallet_sidechain::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = weights::pallet_sidechain::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -557,11 +557,11 @@ parameter_types! {
 
 // Integritee pallet
 impl pallet_claims::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type VestingSchedule = Vesting;
-    type Prefix = Prefix;
-    type MoveClaimOrigin = EnsureRoot<AccountId>;
-    type WeightInfo = weights::pallet_claims::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type VestingSchedule = Vesting;
+	type Prefix = Prefix;
+	type MoveClaimOrigin = EnsureRoot<AccountId>;
+	type WeightInfo = weights::pallet_claims::WeightInfo<Runtime>;
 }
 parameter_types! {
 	pub const MaxWhitelistedReleases: u32 = 10;
@@ -570,10 +570,10 @@ parameter_types! {
 
 // Integritee pallet
 impl pallet_teeracle::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type WeightInfo = weights::pallet_teeracle::WeightInfo<Runtime>;
-    type MaxWhitelistedReleases = MaxWhitelistedReleases;
-    type MaxOracleBlobLen = MaxOracleBlobLen;
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = weights::pallet_teeracle::WeightInfo<Runtime>;
+	type MaxWhitelistedReleases = MaxWhitelistedReleases;
+	type MaxOracleBlobLen = MaxOracleBlobLen;
 }
 
 parameter_types! {
@@ -593,39 +593,39 @@ parameter_types! {
 pub struct NoConversion;
 
 impl ConversionFromAssetBalance<u128, (), u128> for NoConversion {
-    type Error = ();
-    fn from_asset_balance(balance: Balance, _asset_id: ()) -> Result<Balance, Self::Error> {
-        return Ok(balance);
-    }
-    #[cfg(feature = "runtime-benchmarks")]
-    fn ensure_successful(_: ()) {}
+	type Error = ();
+	fn from_asset_balance(balance: Balance, _asset_id: ()) -> Result<Balance, Self::Error> {
+		return Ok(balance);
+	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn ensure_successful(_: ()) {}
 }
 
 impl pallet_treasury::Config for Runtime {
-    type PalletId = TreasuryPalletId;
-    type Currency = pallet_balances::Pallet<Runtime>;
-    type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type RuntimeEvent = RuntimeEvent;
-    type OnSlash = (); // No Proposal
-    type ProposalBond = ProposalBond;
-    type ProposalBondMinimum = ProposalBondMinimum;
-    type ProposalBondMaximum = ProposalBondMaximum;
-    type SpendPeriod = SpendPeriod; //Cannot be 0: Error: Thread 'tokio-runtime-worker' panicked at 'attempt to calculate the remainder with a divisor of zero
-    type Burn = (); //No burn
-    type BurnDestination = (); //No burn
-    type SpendFunds = Bounties;
-    type SpendOrigin = EnsureWithSuccess<EnsureRoot<AccountId>, AccountId, MaxBalance>;
-    type MaxApprovals = MaxApprovals; //0:cannot approve any proposal
-    type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
-    type AssetKind = ();
-    type Beneficiary = AccountId;
-    type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
-    type Paymaster = PayFromAccount<Balances, TreasuryAccount>;
-    type BalanceConverter = NoConversion;
-    type PayoutPeriod = PayoutSpendPeriod;
-    #[cfg(feature = "runtime-benchmarks")]
-    type BenchmarkHelper = ();
+	type PalletId = TreasuryPalletId;
+	type Currency = pallet_balances::Pallet<Runtime>;
+	type ApproveOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type RejectOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type RuntimeEvent = RuntimeEvent;
+	type OnSlash = (); // No Proposal
+	type ProposalBond = ProposalBond;
+	type ProposalBondMinimum = ProposalBondMinimum;
+	type ProposalBondMaximum = ProposalBondMaximum;
+	type SpendPeriod = SpendPeriod; //Cannot be 0: Error: Thread 'tokio-runtime-worker' panicked at 'attempt to calculate the remainder with a divisor of zero
+	type Burn = (); //No burn
+	type BurnDestination = (); //No burn
+	type SpendFunds = Bounties;
+	type SpendOrigin = EnsureWithSuccess<EnsureRoot<AccountId>, AccountId, MaxBalance>;
+	type MaxApprovals = MaxApprovals; //0:cannot approve any proposal
+	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
+	type AssetKind = ();
+	type Beneficiary = AccountId;
+	type BeneficiaryLookup = IdentityLookup<Self::Beneficiary>;
+	type Paymaster = PayFromAccount<Balances, TreasuryAccount>;
+	type BalanceConverter = NoConversion;
+	type PayoutPeriod = PayoutSpendPeriod;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
 }
 
 parameter_types! {
@@ -640,18 +640,18 @@ parameter_types! {
 }
 
 impl pallet_bounties::Config for Runtime {
-    type BountyDepositBase = BountyDepositBase;
-    type BountyDepositPayoutDelay = BountyDepositPayoutDelay;
-    type BountyUpdatePeriod = BountyUpdatePeriod;
-    type CuratorDepositMultiplier = CuratorDepositMultiplier;
-    type CuratorDepositMin = CuratorDepositMin;
-    type CuratorDepositMax = CuratorDepositMax;
-    type BountyValueMinimum = BountyValueMinimum;
-    type ChildBountyManager = ChildBounties;
-    type DataDepositPerByte = DataDepositPerByte;
-    type RuntimeEvent = RuntimeEvent;
-    type MaximumReasonLength = MaximumReasonLength;
-    type WeightInfo = weights::pallet_bounties::WeightInfo<Runtime>;
+	type BountyDepositBase = BountyDepositBase;
+	type BountyDepositPayoutDelay = BountyDepositPayoutDelay;
+	type BountyUpdatePeriod = BountyUpdatePeriod;
+	type CuratorDepositMultiplier = CuratorDepositMultiplier;
+	type CuratorDepositMin = CuratorDepositMin;
+	type CuratorDepositMax = CuratorDepositMax;
+	type BountyValueMinimum = BountyValueMinimum;
+	type ChildBountyManager = ChildBounties;
+	type DataDepositPerByte = DataDepositPerByte;
+	type RuntimeEvent = RuntimeEvent;
+	type MaximumReasonLength = MaximumReasonLength;
+	type WeightInfo = weights::pallet_bounties::WeightInfo<Runtime>;
 }
 
 parameter_types! {
@@ -660,10 +660,10 @@ parameter_types! {
 }
 
 impl pallet_child_bounties::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type MaxActiveChildBountyCount = MaxActiveChildBountyCount;
-    type ChildBountyValueMinimum = ChildBountyValueMinimum;
-    type WeightInfo = weights::pallet_child_bounties::WeightInfo<Runtime>;
+	type RuntimeEvent = RuntimeEvent;
+	type MaxActiveChildBountyCount = MaxActiveChildBountyCount;
+	type ChildBountyValueMinimum = ChildBountyValueMinimum;
+	type WeightInfo = weights::pallet_child_bounties::WeightInfo<Runtime>;
 }
 
 /// Council collective instance declaration.
@@ -679,21 +679,21 @@ parameter_types! {
 }
 
 impl pallet_collective::Config<CouncilInstance> for Runtime {
-    type RuntimeOrigin = RuntimeOrigin;
-    type Proposal = RuntimeCall;
-    type RuntimeEvent = RuntimeEvent;
-    type MotionDuration = CouncilMotionDuration;
-    type MaxProposals = CouncilMaxProposals;
-    type MaxMembers = CouncilMaxMembers;
-    type DefaultVote = pallet_collective::PrimeDefaultVote;
-    type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
-    type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type MaxProposalWeight = MaxProposalWeight;
+	type RuntimeOrigin = RuntimeOrigin;
+	type Proposal = RuntimeCall;
+	type RuntimeEvent = RuntimeEvent;
+	type MotionDuration = CouncilMotionDuration;
+	type MaxProposals = CouncilMaxProposals;
+	type MaxMembers = CouncilMaxMembers;
+	type DefaultVote = pallet_collective::PrimeDefaultVote;
+	type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
+	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type MaxProposalWeight = MaxProposalWeight;
 }
 
 pub type EnsureRootOrMoreThanHalfCouncil = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    pallet_collective::EnsureProportionMoreThan<AccountId, CouncilInstance, 1, 2>,
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilInstance, 1, 2>,
 >;
 
 /// Technical committee collective instance declaration.
@@ -708,30 +708,30 @@ parameter_types! {
 }
 
 impl pallet_collective::Config<TechnicalCommitteeInstance> for Runtime {
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeEvent = RuntimeEvent;
-    type Proposal = RuntimeCall;
-    /// The maximum amount of time (in blocks) for technical committee members to vote on motions.
-    /// Motions may end in fewer blocks if enough votes are cast to determine the result.
-    type MotionDuration = TechnicalMotionDuration;
-    /// The maximum number of Proposlas that can be open in the technical committee at once.
-    type MaxProposals = TechnicalMaxProposals;
-    /// The maximum number of technical committee members.
-    type MaxMembers = TechnicalMaxMembers;
-    type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
-    type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
-    type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
-    type MaxProposalWeight = MaxProposalWeight;
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeEvent = RuntimeEvent;
+	type Proposal = RuntimeCall;
+	/// The maximum amount of time (in blocks) for technical committee members to vote on motions.
+	/// Motions may end in fewer blocks if enough votes are cast to determine the result.
+	type MotionDuration = TechnicalMotionDuration;
+	/// The maximum number of Proposlas that can be open in the technical committee at once.
+	type MaxProposals = TechnicalMaxProposals;
+	/// The maximum number of technical committee members.
+	type MaxMembers = TechnicalMaxMembers;
+	type DefaultVote = pallet_collective::MoreThanMajorityThenPrimeDefaultVote;
+	type WeightInfo = weights::pallet_collective::WeightInfo<Runtime>;
+	type SetMembersOrigin = EnsureRootOrMoreThanHalfCouncil;
+	type MaxProposalWeight = MaxProposalWeight;
 }
 
 pub type EnsureRootOrMoreThanHalfTechnicalCommittee = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 2>,
 >;
 
 pub type EnsureRootOrAllTechnicalCommittee = EitherOfDiverse<
-    EnsureRoot<AccountId>,
-    pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
+	EnsureRoot<AccountId>,
+	pallet_collective::EnsureProportionAtLeast<AccountId, TechnicalCommitteeInstance, 1, 1>,
 >;
 
 parameter_types! {
@@ -747,53 +747,53 @@ parameter_types! {
 }
 
 impl pallet_democracy::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Currency = Balances;
-    type EnactmentPeriod = EnactmentPeriod;
-    type LaunchPeriod = LaunchPeriod;
-    type VotingPeriod = VotingPeriod;
-    type VoteLockingPeriod = EnactmentPeriod;
-    type MinimumDeposit = MinimumDeposit;
-    //// Origin allowed to schedule a SuperMajorityApprove (default decline)
-    /// referendum once it is is legal for an externally proposed referendum
-    type ExternalOrigin = EnsureRootOrMoreThanHalfCouncil;
-    /// Origin allowed to schedule a majority-carries (Simple Majority)
-    /// referendum once it is legal for an externally proposed referendum
-    type ExternalMajorityOrigin = EnsureRootOrMoreThanHalfCouncil;
-    /// Origin allowed to schedule a SuperMajorityAgainst (default accept)
-    /// referendum once it is legal for an externally proposed referendum
-    type ExternalDefaultOrigin = EnsureRootOrMoreThanHalfCouncil;
-    /// Majority of the technical committee can have an ExternalMajority/ExternalDefault vote
-    /// be tabled immediately and with a shorter voting/enactment period.
-    type FastTrackOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
-    type InstantOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
-    type InstantAllowed = InstantAllowed;
-    type FastTrackVotingPeriod = FastTrackVotingPeriod;
-    // To cancel a proposal which has been passed.
-    type CancellationOrigin = EnsureRoot<AccountId>;
-    type BlacklistOrigin = EnsureRootOrMoreThanHalfCouncil;
-    // To cancel a proposal before it has been passed, the technical committee must be unanimous or
-    // Root must agree.
-    type CancelProposalOrigin = EnsureRootOrAllTechnicalCommittee;
-    // Any single technical committee member may veto a coming council proposal, however they can
-    // only do it once and it lasts only for the cooloff period.
-    type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>;
-    type CooloffPeriod = CooloffPeriod;
-    type Slash = Treasury;
-    type Scheduler = Scheduler;
-    type PalletsOrigin = OriginCaller;
-    type MaxVotes = MaxVotes;
-    type WeightInfo = weights::pallet_democracy::WeightInfo<Runtime>;
-    type MaxProposals = MaxProposals;
-    type Preimages = Preimage;
-    type MaxDeposits = ConstU32<100>;
-    type MaxBlacklisted = ConstU32<100>;
-    type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type Currency = Balances;
+	type EnactmentPeriod = EnactmentPeriod;
+	type LaunchPeriod = LaunchPeriod;
+	type VotingPeriod = VotingPeriod;
+	type VoteLockingPeriod = EnactmentPeriod;
+	type MinimumDeposit = MinimumDeposit;
+	//// Origin allowed to schedule a SuperMajorityApprove (default decline)
+	/// referendum once it is is legal for an externally proposed referendum
+	type ExternalOrigin = EnsureRootOrMoreThanHalfCouncil;
+	/// Origin allowed to schedule a majority-carries (Simple Majority)
+	/// referendum once it is legal for an externally proposed referendum
+	type ExternalMajorityOrigin = EnsureRootOrMoreThanHalfCouncil;
+	/// Origin allowed to schedule a SuperMajorityAgainst (default accept)
+	/// referendum once it is legal for an externally proposed referendum
+	type ExternalDefaultOrigin = EnsureRootOrMoreThanHalfCouncil;
+	/// Majority of the technical committee can have an ExternalMajority/ExternalDefault vote
+	/// be tabled immediately and with a shorter voting/enactment period.
+	type FastTrackOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
+	type InstantOrigin = EnsureRootOrMoreThanHalfTechnicalCommittee;
+	type InstantAllowed = InstantAllowed;
+	type FastTrackVotingPeriod = FastTrackVotingPeriod;
+	// To cancel a proposal which has been passed.
+	type CancellationOrigin = EnsureRoot<AccountId>;
+	type BlacklistOrigin = EnsureRootOrMoreThanHalfCouncil;
+	// To cancel a proposal before it has been passed, the technical committee must be unanimous or
+	// Root must agree.
+	type CancelProposalOrigin = EnsureRootOrAllTechnicalCommittee;
+	// Any single technical committee member may veto a coming council proposal, however they can
+	// only do it once and it lasts only for the cooloff period.
+	type VetoOrigin = pallet_collective::EnsureMember<AccountId, TechnicalCommitteeInstance>;
+	type CooloffPeriod = CooloffPeriod;
+	type Slash = Treasury;
+	type Scheduler = Scheduler;
+	type PalletsOrigin = OriginCaller;
+	type MaxVotes = MaxVotes;
+	type WeightInfo = weights::pallet_democracy::WeightInfo<Runtime>;
+	type MaxProposals = MaxProposals;
+	type Preimages = Preimage;
+	type MaxDeposits = ConstU32<100>;
+	type MaxBlacklisted = ConstU32<100>;
+	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
 }
 
 impl orml_xcm::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type SovereignOrigin = EnsureRoot<AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type SovereignOrigin = EnsureRoot<AccountId>;
 }
 
 pub type AssetBalance = Balance;
@@ -802,44 +802,44 @@ pub type AssetBalance = Balance;
 pub struct NoAssetCreators;
 
 impl EnsureOriginWithArg<RuntimeOrigin, AssetIdForTrustBackedAssets> for NoAssetCreators {
-    type Success = AccountId;
+	type Success = AccountId;
 
-    fn try_origin(
-        o: RuntimeOrigin,
-        _a: &AssetIdForTrustBackedAssets,
-    ) -> sp_std::result::Result<Self::Success, RuntimeOrigin> {
-        return Err(o);
-    }
+	fn try_origin(
+		o: RuntimeOrigin,
+		_a: &AssetIdForTrustBackedAssets,
+	) -> sp_std::result::Result<Self::Success, RuntimeOrigin> {
+		return Err(o);
+	}
 
-    #[cfg(feature = "runtime-benchmarks")]
-    fn try_successful_origin(_a: &AssetIdForTrustBackedAssets) -> Result<RuntimeOrigin, ()> {
-        Err(())
-    }
+	#[cfg(feature = "runtime-benchmarks")]
+	fn try_successful_origin(_a: &AssetIdForTrustBackedAssets) -> Result<RuntimeOrigin, ()> {
+		Err(())
+	}
 }
 
 pub type MainAssetsInstance = pallet_assets::Instance1;
 
 impl pallet_assets::Config<MainAssetsInstance> for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Balance = AssetBalance;
-    type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
-    type AssetId = AssetIdForTrustBackedAssets;
-    type AssetIdParameter = parity_scale_codec::Compact<AssetIdForTrustBackedAssets>;
-    type Currency = Balances;
-    type CreateOrigin = NoAssetCreators; //assets can only be created by root
-    type ForceOrigin = EnsureRoot<AccountId>;
-    type AssetDeposit = ConstU128<{ TEER }>;
-    type AssetAccountDeposit = ConstU128<{ TEER }>;
-    type MetadataDepositBase = ConstU128<{ TEER }>;
-    type MetadataDepositPerByte = ConstU128<{ 10 * MILLITEER }>;
-    type ApprovalDeposit = ConstU128<{ 10 * MILLITEER }>;
-    type StringLimit = ConstU32<50>;
-    type Freezer = ();
-    type Extra = ();
-    type CallbackHandle = ();
-    type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
-    #[cfg(feature = "runtime-benchmarks")]
-    type BenchmarkHelper = ();
+	type RuntimeEvent = RuntimeEvent;
+	type Balance = AssetBalance;
+	type RemoveItemsLimit = frame_support::traits::ConstU32<1000>;
+	type AssetId = AssetIdForTrustBackedAssets;
+	type AssetIdParameter = parity_scale_codec::Compact<AssetIdForTrustBackedAssets>;
+	type Currency = Balances;
+	type CreateOrigin = NoAssetCreators; //assets can only be created by root
+	type ForceOrigin = EnsureRoot<AccountId>;
+	type AssetDeposit = ConstU128<{ TEER }>;
+	type AssetAccountDeposit = ConstU128<{ TEER }>;
+	type MetadataDepositBase = ConstU128<{ TEER }>;
+	type MetadataDepositPerByte = ConstU128<{ 10 * MILLITEER }>;
+	type ApprovalDeposit = ConstU128<{ 10 * MILLITEER }>;
+	type StringLimit = ConstU32<50>;
+	type Freezer = ();
+	type Extra = ();
+	type CallbackHandle = ();
+	type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -847,62 +847,62 @@ pub struct AssetRegistryBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
 impl pallet_asset_registry::BenchmarkHelper<AssetIdForTrustBackedAssets>
-for AssetRegistryBenchmarkHelper
+	for AssetRegistryBenchmarkHelper
 {
-    fn get_registered_asset() -> AssetIdForTrustBackedAssets {
-        use sp_runtime::traits::StaticLookup;
+	fn get_registered_asset() -> AssetIdForTrustBackedAssets {
+		use sp_runtime::traits::StaticLookup;
 
-        let root = frame_system::RawOrigin::Root.into();
-        let asset_id = 1;
-        let caller = frame_benchmarking::whitelisted_caller();
-        let caller_lookup = <Runtime as frame_system::Config>::Lookup::unlookup(caller);
-        Assets::force_create(root, asset_id.into(), caller_lookup, true, 1)
-            .expect("Should have been able to force create asset");
-        asset_id
-    }
+		let root = frame_system::RawOrigin::Root.into();
+		let asset_id = 1;
+		let caller = frame_benchmarking::whitelisted_caller();
+		let caller_lookup = <Runtime as frame_system::Config>::Lookup::unlookup(caller);
+		Assets::force_create(root, asset_id.into(), caller_lookup, true, 1)
+			.expect("Should have been able to force create asset");
+		asset_id
+	}
 }
 
 impl pallet_asset_registry::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type ReserveAssetModifierOrigin = EnsureRoot<Self::AccountId>;
-    type Assets = Assets;
-    type WeightInfo = weights::pallet_asset_registry::WeightInfo<Runtime>;
-    #[cfg(feature = "runtime-benchmarks")]
-    type BenchmarkHelper = AssetRegistryBenchmarkHelper;
+	type RuntimeEvent = RuntimeEvent;
+	type ReserveAssetModifierOrigin = EnsureRoot<Self::AccountId>;
+	type Assets = Assets;
+	type WeightInfo = weights::pallet_asset_registry::WeightInfo<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = AssetRegistryBenchmarkHelper;
 }
 
 pub type NativeAndAssets = UnionOf<
-    Balances,
-    Assets,
-    NativeFromLeft,
-    NativeOrWithId<AssetIdForTrustBackedAssets>,
-    AccountId,
+	Balances,
+	Assets,
+	NativeFromLeft,
+	NativeOrWithId<AssetIdForTrustBackedAssets>,
+	AccountId,
 >;
 pub type AscendingLocator = Ascending<AccountId, NativeOrWithId<AssetIdForTrustBackedAssets>>;
 pub type WithFirstAssetLocator =
-WithFirstAsset<Native, AccountId, NativeOrWithId<AssetIdForTrustBackedAssets>>;
+	WithFirstAsset<Native, AccountId, NativeOrWithId<AssetIdForTrustBackedAssets>>;
 
 impl pallet_asset_conversion::Config for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Balance = Balance;
-    type HigherPrecisionBalance = sp_core::U256;
-    type AssetKind = NativeOrWithId<AssetIdForTrustBackedAssets>;
-    type Assets = NativeAndAssets;
-    type PoolId = (Self::AssetKind, Self::AssetKind);
-    type PoolLocator = Chain<WithFirstAssetLocator, AscendingLocator>;
-    type PoolAssetId = u32;
-    type PoolAssets = PoolAssets;
-    type PoolSetupFee = ConstU128<0>; // Asset class deposit fees are sufficient to prevent spam
-    type PoolSetupFeeAsset = Native;
-    type PoolSetupFeeTarget = ResolveAssetTo<AssetConversionOrigin, Self::Assets>;
-    type LiquidityWithdrawalFee = LiquidityWithdrawalFee;
-    type LPFee = ConstU32<3>; // 0.3% swap fee
-    type PalletId = AssetConversionPalletId;
-    type MaxSwapPathLength = ConstU32<3>;
-    type MintMinLiquidity = ConstU128<100>;
-    type WeightInfo = weights::pallet_asset_conversion::WeightInfo<Runtime>;
-    #[cfg(feature = "runtime-benchmarks")]
-    type BenchmarkHelper = ();
+	type RuntimeEvent = RuntimeEvent;
+	type Balance = Balance;
+	type HigherPrecisionBalance = sp_core::U256;
+	type AssetKind = NativeOrWithId<AssetIdForTrustBackedAssets>;
+	type Assets = NativeAndAssets;
+	type PoolId = (Self::AssetKind, Self::AssetKind);
+	type PoolLocator = Chain<WithFirstAssetLocator, AscendingLocator>;
+	type PoolAssetId = u32;
+	type PoolAssets = PoolAssets;
+	type PoolSetupFee = ConstU128<0>; // Asset class deposit fees are sufficient to prevent spam
+	type PoolSetupFeeAsset = Native;
+	type PoolSetupFeeTarget = ResolveAssetTo<AssetConversionOrigin, Self::Assets>;
+	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;
+	type LPFee = ConstU32<3>; // 0.3% swap fee
+	type PalletId = AssetConversionPalletId;
+	type MaxSwapPathLength = ConstU32<3>;
+	type MintMinLiquidity = ConstU128<100>;
+	type WeightInfo = weights::pallet_asset_conversion::WeightInfo<Runtime>;
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
 }
 
 parameter_types! {
@@ -920,28 +920,28 @@ ord_parameter_types! {
 pub type PoolAssetsInstance = pallet_assets::Instance2;
 
 impl pallet_assets::Config<PoolAssetsInstance> for Runtime {
-    type RuntimeEvent = RuntimeEvent;
-    type Balance = Balance;
-    type RemoveItemsLimit = ConstU32<1000>;
-    type AssetId = u32;
-    type AssetIdParameter = u32;
-    type Currency = Balances;
-    type CreateOrigin =
-    AsEnsureOriginWithArg<EnsureSignedBy<AssetConversionOrigin, sp_runtime::AccountId32>>;
-    type ForceOrigin = EnsureRoot<AccountId>;
-    // Deposits are zero because creation/admin is limited to Asset Conversion pallet.
-    type AssetDeposit = ConstU128<0>;
-    type AssetAccountDeposit = ConstU128<0>;
-    type MetadataDepositBase = ConstU128<0>;
-    type MetadataDepositPerByte = ConstU128<0>;
-    type ApprovalDeposit = ApprovalDeposit;
-    type StringLimit = ConstU32<50>;
-    type Freezer = ();
-    type Extra = ();
-    type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
-    type CallbackHandle = ();
-    #[cfg(feature = "runtime-benchmarks")]
-    type BenchmarkHelper = ();
+	type RuntimeEvent = RuntimeEvent;
+	type Balance = Balance;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetId = u32;
+	type AssetIdParameter = u32;
+	type Currency = Balances;
+	type CreateOrigin =
+		AsEnsureOriginWithArg<EnsureSignedBy<AssetConversionOrigin, sp_runtime::AccountId32>>;
+	type ForceOrigin = EnsureRoot<AccountId>;
+	// Deposits are zero because creation/admin is limited to Asset Conversion pallet.
+	type AssetDeposit = ConstU128<0>;
+	type AssetAccountDeposit = ConstU128<0>;
+	type MetadataDepositBase = ConstU128<0>;
+	type MetadataDepositPerByte = ConstU128<0>;
+	type ApprovalDeposit = ApprovalDeposit;
+	type StringLimit = ConstU32<50>;
+	type Freezer = ();
+	type Extra = ();
+	type WeightInfo = weights::pallet_assets::WeightInfo<Runtime>;
+	type CallbackHandle = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
 }
 
 construct_runtime!(
@@ -1003,18 +1003,18 @@ construct_runtime!(
 
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
-    frame_system::CheckNonZeroSender<Runtime>,
-    frame_system::CheckSpecVersion<Runtime>,
-    frame_system::CheckTxVersion<Runtime>,
-    frame_system::CheckGenesis<Runtime>,
-    frame_system::CheckEra<Runtime>,
-    frame_system::CheckNonce<Runtime>,
-    frame_system::CheckWeight<Runtime>,
-    pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_system::CheckNonZeroSender<Runtime>,
+	frame_system::CheckSpecVersion<Runtime>,
+	frame_system::CheckTxVersion<Runtime>,
+	frame_system::CheckGenesis<Runtime>,
+	frame_system::CheckEra<Runtime>,
+	frame_system::CheckNonce<Runtime>,
+	frame_system::CheckWeight<Runtime>,
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =
-generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
 /// Extrinsic type that has already been checked.
 pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, RuntimeCall, SignedExtra>;
 /// Block type as expected by this runtime.
@@ -1026,18 +1026,18 @@ pub type BlockId = generic::BlockId<Block>;
 
 /// Migrations to apply on runtime upgrade.
 pub type Migrations = (
-    migrations::scheduler::v4::PurgeV4Agenda<Runtime>,
-    cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
+	migrations::scheduler::v4::PurgeV4Agenda<Runtime>,
+	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
 );
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
-    Runtime,
-    Block,
-    frame_system::ChainContext<Runtime>,
-    Runtime,
-    AllPalletsWithSystem, // Solochain: AllPalletsReversedWithSystemFirst, Statemint: AllPallets. Which one to take?
-    Migrations,
+	Runtime,
+	Block,
+	frame_system::ChainContext<Runtime>,
+	Runtime,
+	AllPalletsWithSystem, // Solochain: AllPalletsReversedWithSystemFirst, Statemint: AllPallets. Which one to take?
+	Migrations,
 >;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -1046,7 +1046,7 @@ extern crate frame_benchmarking;
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benches {
-    define_benchmarks!(
+	define_benchmarks!(
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_asset_conversion, AssetConversion]
 		[pallet_asset_registry, AssetRegistry]

--- a/polkadot-parachains/integritee-runtime/src/migrations.rs
+++ b/polkadot-parachains/integritee-runtime/src/migrations.rs
@@ -1,0 +1,127 @@
+pub mod scheduler {
+    // this is necessary because migrations from v0 to v3 are no longer available in the scheduler
+    // pallet code and migrating is only possible from v3. The strategy here is to empty the agenda
+    use frame_support::traits::OnRuntimeUpgrade;
+    use frame_system::pallet_prelude::BlockNumberFor;
+    use pallet_scheduler::*;
+    use sp_std::vec::Vec;
+
+    #[cfg(feature = "try-runtime")]
+    use sp_runtime::TryRuntimeError;
+
+    /// The log target.
+    const TARGET: &'static str = "runtime::fix::scheduler::migration";
+
+    pub mod v1 {
+        use super::*;
+        use frame_support::{pallet_prelude::*, traits::schedule};
+
+        #[cfg_attr(any(feature = "std", test), derive(PartialEq, Eq))]
+        #[derive(Clone, RuntimeDebug, Encode, Decode)]
+        pub(crate) struct ScheduledV1<Call, BlockNumber> {
+            maybe_id: Option<Vec<u8>>,
+            priority: schedule::Priority,
+            call: Call,
+            maybe_periodic: Option<schedule::Period<BlockNumber>>,
+        }
+
+        #[frame_support::storage_alias]
+        pub(crate) type Agenda<T: Config> = StorageMap<
+            Pallet<T>,
+            Twox64Concat,
+            BlockNumberFor<T>,
+            Vec<Option<ScheduledV1<<T as Config>::RuntimeCall, BlockNumberFor<T>>>>,
+            ValueQuery,
+        >;
+
+        #[frame_support::storage_alias]
+        pub(crate) type Lookup<T: Config> =
+        StorageMap<Pallet<T>, Twox64Concat, Vec<u8>, TaskAddress<BlockNumberFor<T>>>;
+    }
+
+    pub mod v3 {
+        use super::*;
+        use frame_support::pallet_prelude::*;
+
+        #[frame_support::storage_alias]
+        pub(crate) type Agenda<T: Config> = StorageMap<
+            Pallet<T>,
+            Twox64Concat,
+            BlockNumberFor<T>,
+            Vec<Option<ScheduledV3Of<T>>>,
+            ValueQuery,
+        >;
+
+        #[frame_support::storage_alias]
+        pub(crate) type Lookup<T: Config> =
+        StorageMap<Pallet<T>, Twox64Concat, Vec<u8>, TaskAddress<BlockNumberFor<T>>>;
+    }
+
+    pub mod v4 {
+        use super::*;
+        use frame_support::pallet_prelude::*;
+
+        #[frame_support::storage_alias]
+        pub type Agenda<T: Config> = StorageMap<
+            Pallet<T>,
+            Twox64Concat,
+            BlockNumberFor<T>,
+            BoundedVec<
+                Option<ScheduledOf<T>>,
+                <T as pallet_scheduler::Config>::MaxScheduledPerBlock,
+            >,
+            ValueQuery,
+        >;
+
+        #[cfg(feature = "try-runtime")]
+        pub(crate) type TaskName = [u8; 32];
+
+        #[cfg(feature = "try-runtime")]
+        #[frame_support::storage_alias]
+        pub(crate) type Lookup<T: Config> =
+        StorageMap<Pallet<T>, Twox64Concat, TaskName, TaskAddress<BlockNumberFor<T>>>;
+
+        /// brute-force empty the agenda for V4.
+        pub struct PurgeV4Agenda<T>(sp_std::marker::PhantomData<T>);
+
+        impl<T: Config> OnRuntimeUpgrade for PurgeV4Agenda<T> {
+            #[cfg(feature = "try-runtime")]
+            fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+                let agendas = v1::Agenda::<T>::iter_keys().count() as u32;
+                let lookups = v1::Lookup::<T>::iter_keys().count() as u32;
+                log::info!(target: TARGET, "agendas present which will be dropped: {}/{}...", agendas, lookups);
+                Ok((agendas, lookups).encode())
+            }
+
+            fn on_runtime_upgrade() -> Weight {
+                let onchain_version = Pallet::<T>::on_chain_storage_version();
+                if onchain_version != 4 {
+                    log::warn!(
+						target: TARGET,
+						"skipping migration: executed on wrong storage version.\
+					Expected version == 4, found {:?}",
+						onchain_version,
+					);
+                    return T::DbWeight::get().reads(1);
+                }
+                log::info!(target: TARGET, "migrating from {:?} to 4, purging agenda", onchain_version);
+                let purged_agendas = v1::Agenda::<T>::clear(u32::MAX, None).unique as u64;
+                let purged_lookups = v1::Lookup::<T>::clear(u32::MAX, None).unique as u64;
+                T::DbWeight::get()
+                    .reads_writes(purged_agendas + purged_lookups, purged_agendas + purged_lookups)
+            }
+
+            #[cfg(feature = "try-runtime")]
+            fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+                ensure!(StorageVersion::get::<Pallet<T>>() == 4, "Must upgrade");
+
+                let agendas = Agenda::<T>::iter_keys().count() as u32;
+                ensure!(agendas == 0, "agenda must be empty after now");
+                let lookups = Lookup::<T>::iter_keys().count() as u32;
+                ensure!(lookups == 0, "agenda must be empty after now");
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/polkadot-parachains/integritee-runtime/src/migrations.rs
+++ b/polkadot-parachains/integritee-runtime/src/migrations.rs
@@ -1,127 +1,127 @@
 pub mod scheduler {
-    // this is necessary because migrations from v0 to v3 are no longer available in the scheduler
-    // pallet code and migrating is only possible from v3. The strategy here is to empty the agenda
-    use frame_support::traits::OnRuntimeUpgrade;
-    use frame_system::pallet_prelude::BlockNumberFor;
-    use pallet_scheduler::*;
-    use sp_std::vec::Vec;
+	// this is necessary because migrations from v0 to v3 are no longer available in the scheduler
+	// pallet code and migrating is only possible from v3. The strategy here is to empty the agenda
+	use frame_support::traits::OnRuntimeUpgrade;
+	use frame_system::pallet_prelude::BlockNumberFor;
+	use pallet_scheduler::*;
+	use sp_std::vec::Vec;
 
-    #[cfg(feature = "try-runtime")]
-    use sp_runtime::TryRuntimeError;
+	#[cfg(feature = "try-runtime")]
+	use sp_runtime::TryRuntimeError;
 
-    /// The log target.
-    const TARGET: &'static str = "runtime::fix::scheduler::migration";
+	/// The log target.
+	const TARGET: &'static str = "runtime::fix::scheduler::migration";
 
-    pub mod v1 {
-        use super::*;
-        use frame_support::{pallet_prelude::*, traits::schedule};
+	pub mod v1 {
+		use super::*;
+		use frame_support::{pallet_prelude::*, traits::schedule};
 
-        #[cfg_attr(any(feature = "std", test), derive(PartialEq, Eq))]
-        #[derive(Clone, RuntimeDebug, Encode, Decode)]
-        pub(crate) struct ScheduledV1<Call, BlockNumber> {
-            maybe_id: Option<Vec<u8>>,
-            priority: schedule::Priority,
-            call: Call,
-            maybe_periodic: Option<schedule::Period<BlockNumber>>,
-        }
+		#[cfg_attr(any(feature = "std", test), derive(PartialEq, Eq))]
+		#[derive(Clone, RuntimeDebug, Encode, Decode)]
+		pub(crate) struct ScheduledV1<Call, BlockNumber> {
+			maybe_id: Option<Vec<u8>>,
+			priority: schedule::Priority,
+			call: Call,
+			maybe_periodic: Option<schedule::Period<BlockNumber>>,
+		}
 
-        #[frame_support::storage_alias]
-        pub(crate) type Agenda<T: Config> = StorageMap<
-            Pallet<T>,
-            Twox64Concat,
-            BlockNumberFor<T>,
-            Vec<Option<ScheduledV1<<T as Config>::RuntimeCall, BlockNumberFor<T>>>>,
-            ValueQuery,
-        >;
+		#[frame_support::storage_alias]
+		pub(crate) type Agenda<T: Config> = StorageMap<
+			Pallet<T>,
+			Twox64Concat,
+			BlockNumberFor<T>,
+			Vec<Option<ScheduledV1<<T as Config>::RuntimeCall, BlockNumberFor<T>>>>,
+			ValueQuery,
+		>;
 
-        #[frame_support::storage_alias]
-        pub(crate) type Lookup<T: Config> =
-        StorageMap<Pallet<T>, Twox64Concat, Vec<u8>, TaskAddress<BlockNumberFor<T>>>;
-    }
+		#[frame_support::storage_alias]
+		pub(crate) type Lookup<T: Config> =
+			StorageMap<Pallet<T>, Twox64Concat, Vec<u8>, TaskAddress<BlockNumberFor<T>>>;
+	}
 
-    pub mod v3 {
-        use super::*;
-        use frame_support::pallet_prelude::*;
+	pub mod v3 {
+		use super::*;
+		use frame_support::pallet_prelude::*;
 
-        #[frame_support::storage_alias]
-        pub(crate) type Agenda<T: Config> = StorageMap<
-            Pallet<T>,
-            Twox64Concat,
-            BlockNumberFor<T>,
-            Vec<Option<ScheduledV3Of<T>>>,
-            ValueQuery,
-        >;
+		#[frame_support::storage_alias]
+		pub(crate) type Agenda<T: Config> = StorageMap<
+			Pallet<T>,
+			Twox64Concat,
+			BlockNumberFor<T>,
+			Vec<Option<ScheduledV3Of<T>>>,
+			ValueQuery,
+		>;
 
-        #[frame_support::storage_alias]
-        pub(crate) type Lookup<T: Config> =
-        StorageMap<Pallet<T>, Twox64Concat, Vec<u8>, TaskAddress<BlockNumberFor<T>>>;
-    }
+		#[frame_support::storage_alias]
+		pub(crate) type Lookup<T: Config> =
+			StorageMap<Pallet<T>, Twox64Concat, Vec<u8>, TaskAddress<BlockNumberFor<T>>>;
+	}
 
-    pub mod v4 {
-        use super::*;
-        use frame_support::pallet_prelude::*;
+	pub mod v4 {
+		use super::*;
+		use frame_support::pallet_prelude::*;
 
-        #[frame_support::storage_alias]
-        pub type Agenda<T: Config> = StorageMap<
-            Pallet<T>,
-            Twox64Concat,
-            BlockNumberFor<T>,
-            BoundedVec<
-                Option<ScheduledOf<T>>,
-                <T as pallet_scheduler::Config>::MaxScheduledPerBlock,
-            >,
-            ValueQuery,
-        >;
+		#[frame_support::storage_alias]
+		pub type Agenda<T: Config> = StorageMap<
+			Pallet<T>,
+			Twox64Concat,
+			BlockNumberFor<T>,
+			BoundedVec<
+				Option<ScheduledOf<T>>,
+				<T as pallet_scheduler::Config>::MaxScheduledPerBlock,
+			>,
+			ValueQuery,
+		>;
 
-        #[cfg(feature = "try-runtime")]
-        pub(crate) type TaskName = [u8; 32];
+		#[cfg(feature = "try-runtime")]
+		pub(crate) type TaskName = [u8; 32];
 
-        #[cfg(feature = "try-runtime")]
-        #[frame_support::storage_alias]
-        pub(crate) type Lookup<T: Config> =
-        StorageMap<Pallet<T>, Twox64Concat, TaskName, TaskAddress<BlockNumberFor<T>>>;
+		#[cfg(feature = "try-runtime")]
+		#[frame_support::storage_alias]
+		pub(crate) type Lookup<T: Config> =
+			StorageMap<Pallet<T>, Twox64Concat, TaskName, TaskAddress<BlockNumberFor<T>>>;
 
-        /// brute-force empty the agenda for V4.
-        pub struct PurgeV4Agenda<T>(sp_std::marker::PhantomData<T>);
+		/// brute-force empty the agenda for V4.
+		pub struct PurgeV4Agenda<T>(sp_std::marker::PhantomData<T>);
 
-        impl<T: Config> OnRuntimeUpgrade for PurgeV4Agenda<T> {
-            #[cfg(feature = "try-runtime")]
-            fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-                let agendas = v1::Agenda::<T>::iter_keys().count() as u32;
-                let lookups = v1::Lookup::<T>::iter_keys().count() as u32;
-                log::info!(target: TARGET, "agendas present which will be dropped: {}/{}...", agendas, lookups);
-                Ok((agendas, lookups).encode())
-            }
+		impl<T: Config> OnRuntimeUpgrade for PurgeV4Agenda<T> {
+			#[cfg(feature = "try-runtime")]
+			fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+				let agendas = v1::Agenda::<T>::iter_keys().count() as u32;
+				let lookups = v1::Lookup::<T>::iter_keys().count() as u32;
+				log::info!(target: TARGET, "agendas present which will be dropped: {}/{}...", agendas, lookups);
+				Ok((agendas, lookups).encode())
+			}
 
-            fn on_runtime_upgrade() -> Weight {
-                let onchain_version = Pallet::<T>::on_chain_storage_version();
-                if onchain_version != 4 {
-                    log::warn!(
+			fn on_runtime_upgrade() -> Weight {
+				let onchain_version = Pallet::<T>::on_chain_storage_version();
+				if onchain_version != 4 {
+					log::warn!(
 						target: TARGET,
 						"skipping migration: executed on wrong storage version.\
 					Expected version == 4, found {:?}",
 						onchain_version,
 					);
-                    return T::DbWeight::get().reads(1);
-                }
-                log::info!(target: TARGET, "migrating from {:?} to 4, purging agenda", onchain_version);
-                let purged_agendas = v1::Agenda::<T>::clear(u32::MAX, None).unique as u64;
-                let purged_lookups = v1::Lookup::<T>::clear(u32::MAX, None).unique as u64;
-                T::DbWeight::get()
-                    .reads_writes(purged_agendas + purged_lookups, purged_agendas + purged_lookups)
-            }
+					return T::DbWeight::get().reads(1);
+				}
+				log::info!(target: TARGET, "migrating from {:?} to 4, purging agenda", onchain_version);
+				let purged_agendas = v1::Agenda::<T>::clear(u32::MAX, None).unique as u64;
+				let purged_lookups = v1::Lookup::<T>::clear(u32::MAX, None).unique as u64;
+				T::DbWeight::get()
+					.reads_writes(purged_agendas + purged_lookups, purged_agendas + purged_lookups)
+			}
 
-            #[cfg(feature = "try-runtime")]
-            fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
-                ensure!(StorageVersion::get::<Pallet<T>>() == 4, "Must upgrade");
+			#[cfg(feature = "try-runtime")]
+			fn post_upgrade(_state: Vec<u8>) -> Result<(), TryRuntimeError> {
+				ensure!(StorageVersion::get::<Pallet<T>>() == 4, "Must upgrade");
 
-                let agendas = Agenda::<T>::iter_keys().count() as u32;
-                ensure!(agendas == 0, "agenda must be empty after now");
-                let lookups = Lookup::<T>::iter_keys().count() as u32;
-                ensure!(lookups == 0, "agenda must be empty after now");
+				let agendas = Agenda::<T>::iter_keys().count() as u32;
+				ensure!(agendas == 0, "agenda must be empty after now");
+				let lookups = Lookup::<T>::iter_keys().count() as u32;
+				ensure!(lookups == 0, "agenda must be empty after now");
 
-                Ok(())
-            }
-        }
-    }
+				Ok(())
+			}
+		}
+	}
 }


### PR DESCRIPTION
closes #288 

moreover, the current Lookup seems  to not have been properly migrated to V4 as it can't be decoded by V4. One more reason to purge

merge first (in this order):
1. #289 
2. #290 