### PR TITLE
[CI] bump artifact actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-collator
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integritee-collator-${{ github.sha }}
           path: target/release/integritee-collator
@@ -140,7 +140,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload integritee-collator
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integritee-collator-${{ github.sha }}
           path: target/release/integritee-collator
@@ -208,7 +208,7 @@ jobs:
         run: cargo +stable about generate about.hbs > license.html
 
       - name: Archive license file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: license
           path: license.html
@@ -329,7 +329,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: integritee-collator-${{ github.sha }}
 
@@ -376,7 +376,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Integritee Collator
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: integritee-collator-${{ github.sha }}
 
@@ -421,7 +421,7 @@ jobs:
         runtime: [ "shell", "integritee" ]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Set up Ruby 3
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Upload integritee-collator
         uses: actions/upload-artifact@v4
         with:
-          name: integritee-collator-${{ github.sha }}
+          name: integritee-collator-try-and-benchmark-runtime-${{ github.sha }}
           path: target/release/integritee-collator
 
       - name: Slack Notification


### PR DESCRIPTION
v3 is deprecated and is going to be removed on the 30.01.2025.