### PR TITLE
[ci] disable spec version check in runtime migrations

### DIFF
--- a/.github/workflows/check-migrations.yml
+++ b/.github/workflows/check-migrations.yml
@@ -73,5 +73,6 @@ jobs:
           ./try-runtime \
             --runtime $RUNTIME_BLOB_PATH \
             on-runtime-upgrade --checks=pre-and-post \
+            --disable-spec-version-check \
             $EXTRA_FLAGS \
             live --uri ${{ matrix.runtime.uri }}


### PR DESCRIPTION
It is better to disable the spec-version check than to always fail so that we see if we are missing a runtime migration.