### PR TITLE
(re)allow council to spend treasury funds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
         id: srtool_build
         # srtool-actions@v0.9.2 is bricked for some reason.
         # Fellowship is at v0.8.0 too.
-        uses: paritytech/srtool-actions@v0.9.3
+        uses: chevdor/srtool-actions@v0.8.0
         with:
           image:
             paritytech/srtool:1.84.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,9 +248,10 @@ jobs:
         id: srtool_build
         # srtool-actions@v0.9.2 is bricked for some reason.
         # Fellowship is at v0.8.0 too.
-        uses: chevdor/srtool-actions@v0.8.0
+        uses: paritytech/srtool-actions@v0.9.3
         with:
-          image: paritytech/srtool
+          image:
+            paritytech/srtool:1.84.1
           chain: ${{ matrix.runtime }}
           runtime_dir: polkadot-parachains/${{ matrix.runtime }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,7 @@ jobs:
         # Fellowship is at v0.8.0 too.
         uses: chevdor/srtool-actions@v0.8.0
         with:
-          image:
-            paritytech/srtool:1.84.1
+          image: paritytech/srtool
           chain: ${{ matrix.runtime }}
           runtime_dir: polkadot-parachains/${{ matrix.runtime }}
 

--- a/polkadot-parachains/integritee-kusama/src/lib.rs
+++ b/polkadot-parachains/integritee-kusama/src/lib.rs
@@ -650,7 +650,7 @@ impl pallet_treasury::Config for Runtime {
 	type Burn = (); //No burn
 	type BurnDestination = (); //No burn
 	type SpendFunds = Bounties;
-	type SpendOrigin = EnsureWithSuccess<EnsureRoot<AccountId>, AccountId, MaxBalance>;
+	type SpendOrigin = EnsureWithSuccess<EnsureRootOrMoreThanHalfCouncil, AccountId, MaxBalance>;
 	type MaxApprovals = MaxApprovals; //0:cannot approve any proposal
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
 	type AssetKind = ();

--- a/polkadot-parachains/integritee-polkadot/src/lib.rs
+++ b/polkadot-parachains/integritee-polkadot/src/lib.rs
@@ -650,7 +650,7 @@ impl pallet_treasury::Config for Runtime {
 	type Burn = (); //No burn
 	type BurnDestination = (); //No burn
 	type SpendFunds = Bounties;
-	type SpendOrigin = EnsureWithSuccess<EnsureRoot<AccountId>, AccountId, MaxBalance>;
+	type SpendOrigin = EnsureWithSuccess<EnsureRootOrMoreThanHalfCouncil, AccountId, MaxBalance>;
 	type MaxApprovals = MaxApprovals; //0:cannot approve any proposal
 	type WeightInfo = weights::pallet_treasury::WeightInfo<Runtime>;
 	type AssetKind = ();


### PR DESCRIPTION
since upgrading to the new multi-asset treasury, only root was able to spend treasury funds. This was unintended, because before that upgrade, council was authorized to spend treasury funds which makes payout to teams, collators a.s.o. much leaner

This PR shall restore the initial authorization to council

notes
* initially, every account could request spends, but this is no longer possible
* with this PR, only council members can propose spends to be voted by council
* alternatively, ordinary accounts can register a preimage and submit a referendum if they want to bypass the council and let TEER holders decide